### PR TITLE
fix: now supports any extension for event examples also added missing docs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,5 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["website"]
 }

--- a/.changeset/odd-nails-suffer.md
+++ b/.changeset/odd-nails-suffer.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+"@eventcatalog/core": patch
+---
+
+fix: now supports any extension for event examples also added missing docs

--- a/examples/basic/events/AddedItemToCart/examples/example.js
+++ b/examples/basic/events/AddedItemToCart/examples/example.js
@@ -1,0 +1,17 @@
+var kafka = require('kafka-node'),
+  Consumer = kafka.Consumer,
+  client = new kafka.KafkaClient(),
+  consumer = new Consumer(
+    client,
+    [
+      { topic: 't', partition: 0 },
+      { topic: 'AddedItemToCart', partition: 1 },
+    ],
+    {
+      autoCommit: false,
+    }
+  );
+
+consumer.on('message', function (message) {
+  console.log(message);
+});

--- a/examples/basic/events/AddedItemToCart/index.md
+++ b/examples/basic/events/AddedItemToCart/index.md
@@ -27,4 +27,6 @@ We have a frontend application that allows users to buy things from our store. T
 
 <Mermaid />
 
+<EventExamples title="How to trigger event" />
+
 <Schema />

--- a/packages/create-eventcatalog/templates/default/events/AddedItemToCart/examples/example.js
+++ b/packages/create-eventcatalog/templates/default/events/AddedItemToCart/examples/example.js
@@ -1,0 +1,17 @@
+var kafka = require('kafka-node'),
+  Consumer = kafka.Consumer,
+  client = new kafka.KafkaClient(),
+  consumer = new Consumer(
+    client,
+    [
+      { topic: 't', partition: 0 },
+      { topic: 'AddedItemToCart', partition: 1 },
+    ],
+    {
+      autoCommit: false,
+    }
+  );
+
+consumer.on('message', function (message) {
+  console.log(message);
+});

--- a/packages/create-eventcatalog/templates/default/events/AddedItemToCart/index.md
+++ b/packages/create-eventcatalog/templates/default/events/AddedItemToCart/index.md
@@ -27,4 +27,6 @@ We have a frontend application that allows users to buy things from our store. T
 
 <Mermaid />
 
+<EventExamples title="How to trigger event" />
+
 <Schema />

--- a/packages/eventcatalog/components/Mdx/Admonition.tsx
+++ b/packages/eventcatalog/components/Mdx/Admonition.tsx
@@ -17,7 +17,7 @@ interface AdmonitionProps {
   className?: string;
 }
 
-export default function Admonition({ children, type, className }: AdmonitionProps) {
+export default function Admonition({ children, type, className = '' }: AdmonitionProps) {
   const { color, icon: Icon } = getConfigurationByType(type);
 
   return (

--- a/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
+++ b/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
@@ -111,7 +111,7 @@ function EventSideBar({ event, loadedVersion }: EventSideBarProps) {
                   ? 'bg-blue-400 text-white shadow-md font-bold underline'
                   : 'bg-blue-100 text-blue-800';
                 return (
-                  <li className="text-sm inline ">
+                  <li className="text-sm inline" key={version}>
                     <Link href={`/events/${eventName}/v/${version}`}>
                       <a>
                         <span

--- a/packages/eventcatalog/components/Sidebars/ServiceSidebar.tsx
+++ b/packages/eventcatalog/components/Sidebars/ServiceSidebar.tsx
@@ -137,7 +137,7 @@ function ServiceSidebar({ service }: ServiceSideBarProps) {
           <div className="space-y-3">
             <h2 className="text-sm font-medium text-gray-500">Language</h2>
             {languages.map((value) => (
-              <div className="relative flex items-center mt-2">
+              <div className="relative flex items-center mt-2" key={value}>
                 <div className="absolute flex-shrink-0 flex items-center justify-center">
                   <span
                     className="h-2 w-2 rounded-full"

--- a/packages/eventcatalog/lib/events.ts
+++ b/packages/eventcatalog/lib/events.ts
@@ -120,7 +120,7 @@ const getEventExamplesFromDir = (pathToExamples) => {
       return {
         name: filename,
         snippet: content,
-        langugage: extentionToLanguageMap[extension],
+        langugage: extentionToLanguageMap[extension] || extension,
       };
     });
   } catch (error) {

--- a/packages/eventcatalog/pages/events/[name].tsx
+++ b/packages/eventcatalog/pages/events/[name].tsx
@@ -56,7 +56,15 @@ export const getComponents = ({ event, schema, examples }: any) => ({
     );
   },
   Admonition,
-  EventExamples: (props) => <Examples {...props} examples={examples} showLineNumbers />,
+  EventExamples: (props) => {
+    if (examples.length > 0) {
+      return <Examples {...props} examples={examples} showLineNumbers />;
+    }
+    console.log(
+      'You are using the <EventExamples /> component without any examples, please read https://eventcatalog.dev/docs/events/adding-examples for more information'
+    );
+    return null;
+  },
   Mermaid: ({ title }: { title: string }) => (
     <div className="mx-auto w-full py-10">
       {title && <h2 className="text-lg font-medium text-gray-900 underline">{title}</h2>}

--- a/website/docs/guides/components.md
+++ b/website/docs/guides/components.md
@@ -53,3 +53,30 @@ Supported in
 ```
 
 
+### `<EventExamples />`
+
+Supported in 
+- event markdown files
+
+This component will allow you share code examples for any event. Reasons why you might do this:
+
+- Help the onboarding of the event with code
+- Show developers how to trigger the event
+- Show developers how to consume the events
+
+**Any language is supported!**
+
+#### Rendered Example 
+![UserSignedUp with Code Example](/img/guides/events/UserSignedUpExampleWithExamples.png)
+
+
+#### Usage
+
+```md title=EventExamples Component
+<EventExamples title="How to trigger event" />
+```
+
+EventCatalog will look inside your `examples` directory and every example will be rendered in it's own  tab.
+
+If you want to learn more you can read the [code examples guide](/docs/events/adding-examples).
+

--- a/website/docs/guides/upgrading.md
+++ b/website/docs/guides/upgrading.md
@@ -1,0 +1,30 @@
+---
+sidebar_position: 4
+id: upgrading
+title: Upgrade Catalog
+---  
+
+To upgrade your EventCatalog you can find the package `"@eventcatalog/core"` to upgrade in your `package.json` file.
+
+```json
+{
+  "name": "my-catalog",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    ...
+  },
+  "devDependencies": {
+   ...
+  },
+  "dependencies": {
+    "@eventcatalog/core": "0.0.5"
+  }
+}
+```
+
+Once you upgrade the version number, run `npm install` or `yarn` to install the latest updates.
+
+:::tip
+If you don't see the changes you expect, try removing the `.eventcatalog-core` folder, `node_modules` folder and install fresh again.
+:::

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -44,6 +44,7 @@ const sidebars = {
         'guides/customise',
         'guides/components',
         'guides/deployment',
+        'guides/upgrading',
       ],
     },
   ],


### PR DESCRIPTION
## Motivation

Fix for #48 and also added missing docs for `upgrading eventcatalog`
