### PR TITLE
Fix event typo in adding examples

### DIFF
--- a/website/docs/guides/events/events-adding-examples.md
+++ b/website/docs/guides/events/events-adding-examples.md
@@ -40,12 +40,12 @@ You can choose where you want to render it within your markdown file and you jus
 
 Let's say we have a `UserCreated` event in `/events/UserCreated/index.md`.
 
-```mdx title="/events/UserSignedUp/index.md"
+```mdx title="/events/UserCreated/index.md"
 ---
-name: UserSignedUp
+name: UserCreated
 version: 0.0.1
 summary: |
-  Tells us when the user has signed up
+  Tells us when the user has been created
 consumers:
     - Email Platform
 producers:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix typo in page https://eventcatalog.dev/docs/events/adding-examples/ that was preventing me from correctly displaying the code example. The markdown file was referencing UserSignedUp and the example provided was for UserCreated.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.