### PR TITLE
feat: when creating event using util with schema it now adds schema c…

### DIFF
--- a/.changeset/eighty-icons-rush.md
+++ b/.changeset/eighty-icons-rush.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/utils": patch
+---
+
+feat: when creating event using util with schema it now adds schema c…

--- a/packages/eventcatalog-utils/package.json
+++ b/packages/eventcatalog-utils/package.json
@@ -27,6 +27,6 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "@eventcatalog/types": "0.0.3"
+    "@eventcatalog/types": "^0.0.3"
   }
 }

--- a/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
+++ b/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
@@ -22,10 +22,21 @@ const {
 });
 
 describe('eventcatalog-utils', () => {
+  afterEach(() => {
+    try {
+      fs.rmdirSync(path.join(CATALOG_DIRECTORY, 'events', 'My New Event'), { recursive: true });
+      fs.rmdirSync(path.join(CATALOG_DIRECTORY, 'events', 'My Event That Overrides Content'), { recursive: true });
+      fs.rmdirSync(path.join(CATALOG_DIRECTORY, 'events', 'My Versioned Event'), { recursive: true });
+      fs.rmdirSync(path.join(CATALOG_DIRECTORY, 'services', 'My New Service'), { recursive: true });
+    } catch (error) {
+      console.log('Nothing to remove');
+    }
+  });
+
   describe('events', () => {
     describe('getEventFromCatalog', () => {
       it('returns the given event name from the catalog', () => {
-        const { content, data } = getEventFromCatalog('OrderComplete');
+        const { content, data, raw } = getEventFromCatalog('OrderComplete');
 
         expect(data).toEqual({
           name: 'OrderComplete',
@@ -37,6 +48,7 @@ describe('eventcatalog-utils', () => {
         });
 
         expect(content).toMatchMarkdown('# Testing');
+        expect(raw).toBeDefined();
       });
 
       it('returns null when a given event name does not exist in the catalog', () => {
@@ -225,6 +237,37 @@ describe('eventcatalog-utils', () => {
             - dBoyne
         ---
         <Mermaid />`);
+
+        // clean up
+        fs.rmdirSync(path.join(eventPath), { recursive: true });
+      });
+
+      it('when writing an event with a schema the default markdown includes the schema component', () => {
+        const event = {
+          name: 'My New Event',
+          summary: 'This is summary for my event',
+          owners: ['dBoyne'],
+        };
+
+        const { path: eventPath } = writeEventToCatalog(event, {
+          schema: { extension: 'json', fileContent: JSON.stringify({ test: true }, null, 4) },
+        });
+
+        expect(fs.existsSync(eventPath)).toEqual(true);
+
+        const result = fs.readFileSync(path.join(eventPath, 'index.md'), 'utf-8');
+
+        expect(result).toMatchMarkdown(`
+        ---
+        name: 'My New Event'
+        summary: 'This is summary for my event'
+        owners:
+            - dBoyne
+        ---
+        <Mermaid />
+
+        <Schema />
+        `);
 
         // clean up
         fs.rmdirSync(path.join(eventPath), { recursive: true });

--- a/packages/eventcatalog-utils/src/markdown-builder.ts
+++ b/packages/eventcatalog-utils/src/markdown-builder.ts
@@ -11,7 +11,6 @@ export default ({
   customContent?: string;
   includeSchemaComponent?: boolean;
 }) => {
-  // eslint-disable-next-line no-multi-assign
   const customJSON2MD = (content: any) => {
     json2md.converters.mermaid = (render) => (render ? '<Mermaid />' : '');
     json2md.converters.schema = (render) => (render ? '<Schema />' : '');

--- a/packages/eventcatalog-utils/src/markdown-builder.ts
+++ b/packages/eventcatalog-utils/src/markdown-builder.ts
@@ -2,11 +2,23 @@ import YAML from 'yamljs';
 import json2md from 'json2md';
 import { Event, Service } from '@eventcatalog/types';
 
-export default ({ frontMatterObject, customContent }: { frontMatterObject: Service | Event; customContent?: string }) => {
+export default ({
+  frontMatterObject,
+  customContent,
+  includeSchemaComponent = false,
+}: {
+  frontMatterObject: Service | Event;
+  customContent?: string;
+  includeSchemaComponent?: boolean;
+}) => {
   // eslint-disable-next-line no-multi-assign
-  const customJSON2MD = (json2md.converters.mermaid = (render) => (render ? '<Mermaid />' : ''));
+  const customJSON2MD = (content: any) => {
+    json2md.converters.mermaid = (render) => (render ? '<Mermaid />' : '');
+    json2md.converters.schema = (render) => (render ? '<Schema />' : '');
+    return json2md(content);
+  };
 
-  const content = [{ h1: frontMatterObject.name, mermaid: true }];
+  const content = [{ mermaid: true }, { schema: includeSchemaComponent }];
 
   return `---
 ${YAML.stringify(frontMatterObject)}---

--- a/packages/eventcatalog-utils/src/services.ts
+++ b/packages/eventcatalog-utils/src/services.ts
@@ -10,7 +10,10 @@ const readMarkdownFile = (pathToFile: string) => {
   const file = fs.readFileSync(pathToFile, {
     encoding: 'utf-8',
   });
-  return matter(file);
+  return {
+    parsed: matter(file),
+    raw: file,
+  };
 };
 
 export const buildServiceMarkdownForCatalog =
@@ -23,7 +26,11 @@ export const getAllServicesFromCatalog =
   (): any[] => {
     const servicesDir = path.join(catalogDirectory, 'services');
     const folders = fs.readdirSync(servicesDir);
-    return folders.map((folder) => getServiceFromCatalog({ catalogDirectory })(folder));
+    return folders.map((folder) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { raw, ...service }: any = getServiceFromCatalog({ catalogDirectory })(folder);
+      return service;
+    });
   };
 
 export const getServiceFromCatalog =
@@ -31,10 +38,11 @@ export const getServiceFromCatalog =
   (seriveName: string) => {
     try {
       // Read the directory to get the stuff we need.
-      const event = readMarkdownFile(path.join(catalogDirectory, 'services', seriveName, 'index.md'));
+      const { parsed: parsedService, raw } = readMarkdownFile(path.join(catalogDirectory, 'services', seriveName, 'index.md'));
       return {
-        data: event.data,
-        content: event.content,
+        data: parsedService.data,
+        content: parsedService.content,
+        raw,
       };
     } catch (error) {
       return null;


### PR DESCRIPTION
## Motivation

When creating events with the util functions, by default it returns markdown content (with just the Mermaid component).

If user passes through a schema too, the schema component is now rendered with the mermaid.

Also when users get services or events from catalog, it now returns the `raw` value, which is the file itself without being parsed.
