### PR TITLE
fix: generator now runs outside of test env

### DIFF
--- a/.changeset/purple-islands-cheer.md
+++ b/.changeset/purple-islands-cheer.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat: fix-generator

--- a/packages/eventcatalog/scripts/generate.js
+++ b/packages/eventcatalog/scripts/generate.js
@@ -19,7 +19,7 @@ const generate = async () => {
   await Promise.all(plugins);
 };
 
-if (!process.env.NODE_ENV === 'test') {
+if (process.env.NODE_ENV !== 'test') {
   generate();
 }
 


### PR DESCRIPTION
## Motivation

Some code bug checking environment variables when running the generator. The check is now correct.

#84
