### PR TITLE
fix: edit url is now optional in not found pages and no longer fetche…

### DIFF
--- a/.changeset/smooth-berries-attack.md
+++ b/.changeset/smooth-berries-attack.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: edit url is now optional in not found pages and no longer fetche…

--- a/packages/eventcatalog/components/NotFound/index.tsx
+++ b/packages/eventcatalog/components/NotFound/index.tsx
@@ -4,13 +4,13 @@ import url from 'url';
 interface NotFoundProps {
   type: 'service' | 'event';
   name: string;
-  editUrl: string;
+  editUrl?: string;
 }
 
 export default function Example(props: NotFoundProps) {
   const { type, name, editUrl } = props;
 
-  const urlToAddPage = url.resolve(editUrl, `${type}/${name}`);
+  const urlToAddPage = editUrl ? url.resolve(editUrl, `${type}/${name}`) : '';
 
   return (
     <main className="min-h-full bg-cover bg-top sm:bg-top h-screen">
@@ -23,17 +23,19 @@ export default function Example(props: NotFoundProps) {
           Documentation for {type} <span className="underline">{name}</span> is missing!
         </p>
         <p className="mt-4 text-xs text-gray-400">Help the eco-system and add the documentation for others ❤️ </p>
-        <div className="mt-12">
-          <a
-            href={urlToAddPage}
-            target="_blank"
-            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black bg-opacity-75 "
-            rel="noreferrer"
-          >
-            <DocumentAddIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-            Add <span className="underline px-1">{name}</span> documentation
-          </a>
-        </div>
+        {urlToAddPage && (
+          <div className="mt-12">
+            <a
+              href={urlToAddPage}
+              target="_blank"
+              className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black bg-opacity-75 "
+              rel="noreferrer"
+            >
+              <DocumentAddIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
+              Add <span className="underline px-1">{name}</span> documentation
+            </a>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/packages/eventcatalog/components/NotFound/index.tsx
+++ b/packages/eventcatalog/components/NotFound/index.tsx
@@ -1,5 +1,4 @@
 import { DocumentAddIcon } from '@heroicons/react/solid';
-import url from 'url';
 
 interface NotFoundProps {
   type: 'service' | 'event';
@@ -9,8 +8,6 @@ interface NotFoundProps {
 
 export default function Example(props: NotFoundProps) {
   const { type, name, editUrl } = props;
-
-  const urlToAddPage = editUrl ? url.resolve(editUrl, `${type}/${name}`) : '';
 
   return (
     <main className="min-h-full bg-cover bg-top sm:bg-top h-screen">
@@ -23,10 +20,10 @@ export default function Example(props: NotFoundProps) {
           Documentation for {type} <span className="underline">{name}</span> is missing!
         </p>
         <p className="mt-4 text-xs text-gray-400">Help the eco-system and add the documentation for others ❤️ </p>
-        {urlToAddPage && (
+        {editUrl && (
           <div className="mt-12">
             <a
-              href={urlToAddPage}
+              href={editUrl}
               target="_blank"
               className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-black bg-opacity-75 "
               rel="noreferrer"

--- a/packages/eventcatalog/pages/events/[name].tsx
+++ b/packages/eventcatalog/pages/events/[name].tsx
@@ -2,7 +2,6 @@ import Head from 'next/head';
 import { MDXRemote } from 'next-mdx-remote';
 
 import { Event } from '@eventcatalog/types';
-import { editUrl } from '../../eventcatalog.config';
 import Admonition from '@/components/Mdx/Admonition';
 import Examples from '@/components/Mdx/Examples';
 
@@ -69,9 +68,11 @@ export default function Events(props: EventsPageProps) {
   const { event, markdown, loadedVersion, notFound } = props;
   const { getEditUrl, hasEditUrl } = useUrl();
 
-  if (notFound) return <NotFound type="event" name={event.name} editUrl={editUrl} />;
-
   const { name, summary, draft, schema, examples, version } = event;
+
+  if (notFound)
+    return <NotFound type="event" name={event.name} editUrl={hasEditUrl ? getEditUrl(`/events/${name}/index.md`) : ''} />;
+
   const { lastModifiedDate } = markdown;
 
   const pages = [

--- a/packages/eventcatalog/pages/services/[name].tsx
+++ b/packages/eventcatalog/pages/services/[name].tsx
@@ -39,7 +39,9 @@ export default function Services(props: ServicesPageProps) {
   const { getEditUrl, hasEditUrl } = useUrl();
 
   if (notFound)
-    return <NotFound type="service" name={service.name} editUrl={hasEditUrl ? getEditUrl(`/services/${service.name}/index.md`) : ''} />;
+    return (
+      <NotFound type="service" name={service.name} editUrl={hasEditUrl ? getEditUrl(`/services/${service.name}/index.md`) : ''} />
+    );
 
   const { name, summary, draft } = service;
   const { lastModifiedDate } = markdown;

--- a/packages/eventcatalog/pages/services/[name].tsx
+++ b/packages/eventcatalog/pages/services/[name].tsx
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import { MDXRemote } from 'next-mdx-remote';
 import { Service } from '@eventcatalog/types';
-import { editUrl } from '../../eventcatalog.config.js';
 import ContentView from '@/components/ContentView';
 import { getAllServices, getServiceByName } from '@/lib/services';
 
@@ -39,7 +38,8 @@ export default function Services(props: ServicesPageProps) {
   const { service, markdown, notFound } = props;
   const { getEditUrl, hasEditUrl } = useUrl();
 
-  if (notFound) return <NotFound type="service" name={service.name} editUrl={editUrl} />;
+  if (notFound)
+    return <NotFound type="service" name={service.name} editUrl={hasEditUrl ? getEditUrl(`/events/${name}/index.md`) : ''} />;
 
   const { name, summary, draft } = service;
   const { lastModifiedDate } = markdown;

--- a/packages/eventcatalog/pages/services/[name].tsx
+++ b/packages/eventcatalog/pages/services/[name].tsx
@@ -39,7 +39,7 @@ export default function Services(props: ServicesPageProps) {
   const { getEditUrl, hasEditUrl } = useUrl();
 
   if (notFound)
-    return <NotFound type="service" name={service.name} editUrl={hasEditUrl ? getEditUrl(`/events/${name}/index.md`) : ''} />;
+    return <NotFound type="service" name={service.name} editUrl={hasEditUrl ? getEditUrl(`/services/${service.name}/index.md`) : ''} />;
 
   const { name, summary, draft } = service;
   const { lastModifiedDate } = markdown;


### PR DESCRIPTION
## Motivation

Thanks to @otbe in #93, the optional editUrl was blowing up the build.

This PR refactors the pages that were calling the editUrl directly from the config file and now use the hook to get them.

Also the `<NotFound/>` component now has `editUrl` prop as optional.
