### PR TITLE
feat: adding more mermaid support in mdx

### DIFF
--- a/.changeset/stale-fans-peel.md
+++ b/.changeset/stale-fans-peel.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat: adding more mermaid support in mdx

--- a/examples/basic/events/AddedItemToCart/index.md
+++ b/examples/basic/events/AddedItemToCart/index.md
@@ -26,10 +26,7 @@ This event can be triggered multiple times per customer. Everytime the customer 
 
 We have a frontend application that allows users to buy things from our store. This front end interacts directly with the `Basket Service` to add items to the cart. The `Basket Service` will raise the events.
 
-
-### Consumer / Producer Diagram
-
-<Mermaid />
+<Mermaid title="Consumer / Producer Diagram" />
 
 <EventExamples title="How to trigger event" />
 

--- a/packages/eventcatalog/components/Mermaid/index.tsx
+++ b/packages/eventcatalog/components/Mermaid/index.tsx
@@ -30,17 +30,30 @@ interface MermaidProps {
   data: Event | Service;
   source: 'event' | 'service';
   rootNodeColor?: string;
+  charts?: string[];
 }
 
-function Mermaid({ data, source = 'event', rootNodeColor }: MermaidProps) {
+function Mermaid({ data, source = 'event', rootNodeColor, charts }: MermaidProps) {
+  useEffect(() => {
+    mermaid.contentLoaded();
+  }, []);
+
+  if (charts) {
+    return (
+      <>
+        {charts.map((content, index) => (
+          <div key={`chart-${index}`} className="mermaid">
+            {content}
+          </div>
+        ))}
+      </>
+    );
+  }
   const mermaidChart =
     source === 'event'
       ? buildMermaidFlowChartForEvent(data as Event, rootNodeColor)
       : buildMermaidFlowChartForService(data as Service, rootNodeColor);
 
-  useEffect(() => {
-    mermaid.contentLoaded();
-  }, []);
   return <div className="mermaid">{mermaidChart}</div>;
 }
 

--- a/packages/eventcatalog/pages/events/[name].tsx
+++ b/packages/eventcatalog/pages/events/[name].tsx
@@ -56,10 +56,10 @@ export const getComponents = ({ event, schema, examples }: any) => ({
     );
     return null;
   },
-  Mermaid: ({ title }: { title: string }) => (
+  Mermaid: ({ title, charts }: { title: string; charts?: string[] }) => (
     <div className="mx-auto w-full py-10">
       {title && <h2 className="text-lg font-medium text-gray-900 underline">{title}</h2>}
-      <Mermaid source="event" data={event} rootNodeColor={getBackgroundColor(event.name)} />
+      <Mermaid source="event" data={event} rootNodeColor={getBackgroundColor(event.name)} charts={charts} />
     </div>
   ),
 });

--- a/packages/eventcatalog/pages/services/[name].tsx
+++ b/packages/eventcatalog/pages/services/[name].tsx
@@ -20,18 +20,20 @@ interface ServicesPageProps {
   notFound?: boolean;
 }
 
-function MermaidComponent({ title, service }: { title: string; service: Service }) {
+function MermaidComponent({ title, service, charts }: { title: string; service: Service; charts?: string[] }) {
   return (
     <div className="mx-auto w-full py-10">
       {title && <h2 className="text-lg font-medium text-gray-900 underline">{title}</h2>}
-      <Mermaid source="service" data={service} rootNodeColor={getBackgroundColor(service.name)} />
+      <Mermaid source="service" data={service} rootNodeColor={getBackgroundColor(service.name)} charts={charts} />
     </div>
   );
 }
 
 const getComponents = (service) => ({
   Admonition,
-  Mermaid: ({ title }: { title: string }) => <MermaidComponent service={service} title={title} />,
+  Mermaid: ({ title, charts }: { title: string; charts?: string[] }) => (
+    <MermaidComponent service={service} title={title} charts={charts} />
+  ),
 });
 
 export default function Services(props: ServicesPageProps) {

--- a/website/docs/guides/components.md
+++ b/website/docs/guides/components.md
@@ -15,11 +15,42 @@ For more information check out the [schema guide for events](/docs/events/adding
 
 ### `<Mermaid />`
 
-Supported in 
+
+This component will render [mermaid diagrams](https://mermaid-js.github.io/mermaid/#/) into your documents.
+
+If you use `<Mermaid />` without any props EventCatalog will render the relationships between your consumers and producers.
+
+If you would like to **render custom** mermaid diagrams you can use the `charts` prop on the diagram.
+
+Read [Mermaid documentation](https://mermaid-js.github.io/mermaid/#/) if you want to learn what other graphs you can render.
+
+#### Support
+
+You can use this MDX component inside
 - event markdown files
 - service markdown files
 
-This component will render your mermaid diagrams into the document. 
+#### Props 
+
+<APITable>
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | '' | Title to render above your chart |
+| `charts` | `string[]` | [] | An array of [mermaid charts](https://mermaid-js.github.io/mermaid/#/) to render to the your document |
+
+</APITable>
+
+#### Usage
+
+```md title="Render the default graphs for your events and services"
+<Mermaid />
+```
+
+```md title="Render any Mermaid Graph"
+<Mermaid title="Event Rules & Targets" charts={[`flowchart LR 
+Start --> Stop`]} />
+```
 
 :::tip
 Remember the relationship between events and services is stored within the event itself through the `producer` and `consumer` frontmatter properties.


### PR DESCRIPTION
## Motivation

Adding more mermaid support in the `<Mermaid />` MDX component.

Using the `charts` prop you can now render any Mermaid information you want.

This allows users to get more from the mermaid library and render any kind of diagram they like in their docs.

