### PR TITLE
feat: allow default frontmatter when creating events

### DIFF
--- a/.changeset/fair-readers-flash.md
+++ b/.changeset/fair-readers-flash.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/utils": patch
+"@eventcatalog/core": patch
+---
+
+feat: allow default frontmatter when creating events

--- a/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
+++ b/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
@@ -421,6 +421,66 @@ describe('eventcatalog-utils', () => {
 
           fs.rmdirSync(path.join(updatedEventPath), { recursive: true });
         });
+
+        describe('frontMatterToCopyToNewVersions', () => {
+          it('when automatically versioning an event the frontmatter is copied to the new event with any properties specified', () => {
+            const event = {
+              name: 'My Event That Already Exists',
+              version: '1.0.0',
+              summary: 'This is summary for my event',
+              owners: ['dBoyne', 'anotherUser'],
+            };
+
+            const { path: eventPath } = writeEventToCatalog(event, {
+              useMarkdownContentFromExistingEvent: true,
+              markdownContent: '# My Content',
+            });
+
+            const result = fs.readFileSync(path.join(eventPath, 'index.md'), 'utf-8');
+
+            expect(result).toMatchMarkdown(`
+             ---
+             name: 'My Event That Already Exists'
+             version: 1.0.0
+             summary: 'This is summary for my event'
+             owners:
+                 - dBoyne
+                 - anotherUser
+             ---
+             # My Content`);
+
+            const updatedEvent = {
+              name: 'My Event That Already Exists',
+              version: '1.2.0',
+              summary: 'New summary of event',
+              producers: ['random'],
+            };
+
+            const { path: updatedEventPath } = writeEventToCatalog(updatedEvent, {
+              useMarkdownContentFromExistingEvent: true,
+              frontMatterToCopyToNewVersions: {
+                owners: true,
+              },
+            });
+
+            const newFileContents = fs.readFileSync(path.join(eventPath, 'index.md'), 'utf-8');
+
+            expect(newFileContents).toMatchMarkdown(`
+            ---
+            name: 'My Event That Already Exists'
+            version: 1.2.0
+            summary: 'New summary of event'
+            producers:
+                - random
+            owners:
+                - dBoyne
+                - anotherUser
+            ---
+            # My Content`);
+
+            fs.rmdirSync(path.join(updatedEventPath), { recursive: true });
+          });
+        });
       });
     });
 

--- a/packages/eventcatalog-utils/src/types.ts
+++ b/packages/eventcatalog-utils/src/types.ts
@@ -24,10 +24,20 @@ export interface CodeExample {
   fileContent: string;
 }
 
+export interface FrontMatterAllowedToCopy {
+  owners?: boolean;
+  externalLinks?: boolean;
+  domains?: boolean;
+  consumers?: boolean;
+  producers?: boolean;
+  summary?: boolean;
+}
+
 export interface WriteEventToCatalogOptions {
   schema?: SchemaFile;
   codeExamples?: CodeExample[] | [];
   useMarkdownContentFromExistingEvent?: boolean;
   markdownContent?: string;
+  frontMatterToCopyToNewVersions?: FrontMatterAllowedToCopy;
   versionExistingEvent?: boolean;
 }

--- a/packages/eventcatalog/components/SyntaxHighlighter.tsx
+++ b/packages/eventcatalog/components/SyntaxHighlighter.tsx
@@ -23,7 +23,7 @@ function SyntaxHighlighter({ language, name = '', ...props }: any) {
       >
         {showCopied ? 'Copied' : 'Copy'}
       </button>
-      <PrismSyntaxHighlighter style={codeStyle} language={language} {...props} wrapLines>
+      <PrismSyntaxHighlighter style={codeStyle} language={language} {...props} wrapLines className="max-h-96 overflow-auto">
         {props.children.replace(regex, '\n')}
       </PrismSyntaxHighlighter>
       {name && <span className="-mb-2 block text-xs text-right font-bold">{name}</span>}

--- a/packages/eventcatalog/pages/_app.tsx
+++ b/packages/eventcatalog/pages/_app.tsx
@@ -12,6 +12,8 @@ export default ({ Component, pageProps }: AppProps) => (
       <script src="//unpkg.com/three" />
       <script src="//unpkg.com/three/examples/js/renderers/CSS2DRenderer.js" />
 
+      <link rel="stylesheet" href="https://cdn.bootcss.com/font-awesome/4.7.0/css/font-awesome.css" />
+
       <meta
         name="description"
         content="An open source project to Discover, Explore and Document your Event Driven Architectures."


### PR DESCRIPTION
## Motivation

Updates to the utils allow users to use `write event` but specify default properties for frontmatter values.

This allows API users to preserve frontmatter properties when creating new events.

An example might be if users have `owners` in their existing catalog files, they can move these onto the new event when it's created.

---

Also added some fixs for max height on schema files and also include font-awesome css file for mermaid diagrams.