### PR TITLE
fix: now renders events without targets or rules

### DIFF
--- a/.changeset/six-hornets-refuse.md
+++ b/.changeset/six-hornets-refuse.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/plugin-doc-generator-amazon-eventbridge": patch
+---
+
+fix: now renders events without targets or rules

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/assets/aws-mock-responses/client-schemas.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/assets/aws-mock-responses/client-schemas.ts
@@ -10,12 +10,35 @@ const describeSchemas = {
   VersionCreatedDate: '2022-01-20T06:58:30.000Z',
 };
 
+const buildOpenAPIResponse = ({ eventName }) => ({
+  Content: `{"openapi":"3.0.0","info":{"version":"1.0.0","title":"${eventName}"},"paths":{},"components":{"schemas":{"AWSEvent":{"type":"object","required":["detail-type","resources","detail","id","source","time","region","version","account"],"x-amazon-events-detail-type":"${eventName}","x-amazon-events-source":"users","properties":{"detail":{"$ref":"#/components/schemas/${eventName}"},"account":{"type":"string"},"detail-type":{"type":"string"},"id":{"type":"string"},"region":{"type":"string"},"resources":{"type":"array","items":{"type":"object"}},"source":{"type":"string"},"time":{"type":"string","format":"date-time"},"version":{"type":"string"}}},"${eventName}":{"type":"object","required":["data"],"properties":{"data":{"$ref":"#/components/schemas/Data"}}},"Data":{"type":"object","required":["id"],"properties":{"id":{"type":"string"}}}}}}`,
+  LastModified: '2022-01-20T06:58:30.000Z',
+  SchemaArn: `arn:aws:schemas:us-west-1:312708401777:schema/discovered-schemas/users@${eventName}`,
+  SchemaName: eventName,
+  SchemaVersion: '1',
+  Tags: {},
+  Type: 'OpenApi3',
+  VersionCreatedDate: '2022-01-20T06:58:30.000Z',
+});
+
 const exportSchema = {
   Content:
     '{"$schema":"http://json-schema.org/draft-04/schema#","title":"UserCreated","definitions":{"Data":{"properties":{"id":{"type":"string"}},"required":["id"],"type":"object"},"UserCreated":{"properties":{"data":{"$ref":"#/definitions/Data"}},"required":["data"],"type":"object"}},"properties":{"account":{"type":"string"},"detail":{"$ref":"#/definitions/UserCreated"},"detail-type":{"type":"string"},"id":{"type":"string"},"region":{"type":"string"},"resources":{"items":{"type":"object"},"type":"array"},"source":{"type":"string"},"time":{"format":"date-time","type":"string"},"version":{"type":"string"}},"required":["detail-type","resources","detail","id","source","time","region","version","account"],"type":"object","x-amazon-events-detail-type":"userCreated","x-amazon-events-source":"users"}',
   SchemaName: 'users@UserCreated',
   SchemaVersion: '1',
   Type: 'JSONSchemaDraft4',
+};
+
+const buildSchema = ({ eventName }) => {
+  const namePart = eventName.split('@')[1];
+  const detailType = `${namePart.charAt(0).toLowerCase()}${namePart.slice(1, namePart.length)}`;
+
+  return {
+    Content: `{"$schema":"http://json-schema.org/draft-04/schema#","title":"${eventName}","definitions":{"Data":{"properties":{"id":{"type":"string"}},"required":["id"],"type":"object"},"${eventName}":{"properties":{"data":{"$ref":"#/definitions/Data"}},"required":["data"],"type":"object"}},"properties":{"account":{"type":"string"},"detail":{"$ref":"#/definitions/${eventName}"},"detail-type":{"type":"string"},"id":{"type":"string"},"region":{"type":"string"},"resources":{"items":{"type":"object"},"type":"array"},"source":{"type":"string"},"time":{"format":"date-time","type":"string"},"version":{"type":"string"}},"required":["detail-type","resources","detail","id","source","time","region","version","account"],"type":"object","x-amazon-events-detail-type":"${detailType}","x-amazon-events-source":"users"}`,
+    SchemaName: eventName,
+    SchemaVersion: '1',
+    Type: 'JSONSchemaDraft4',
+  };
 };
 
 const listSchemas = {
@@ -27,6 +50,13 @@ const listSchemas = {
       Tags: {},
       VersionCount: 1,
     },
+    {
+      LastModified: '2022-01-20T06:58:30.000Z',
+      SchemaArn: 'arn:aws:schemas:us-west-1:312708401777:schema/discovered-schemas/users@UserDeleted',
+      SchemaName: 'users@UserDeleted',
+      Tags: {},
+      VersionCount: 1,
+    },
   ],
 };
 
@@ -34,4 +64,6 @@ export default {
   describeSchemas,
   exportSchema,
   listSchemas,
+  buildSchema,
+  buildOpenAPIResponse,
 };

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/assets/event-markdown-snapshot.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/assets/event-markdown-snapshot.ts
@@ -1,3 +1,14 @@
+const generatedUserDeletedWithNoRulesOrTargetsMarkdownFile = `---
+name: users@UserDeleted
+version: '1'
+summary: 'Found on the "test-event-bus" Amazon EventBridge bus.'
+externalLinks:
+    - {label: 'View Schema AWS Console', url: 'https://eu-west-1.console.aws.amazon.com/events/home?region=eu-west-1#/registries/discovered-schemas/schemas/users@UserDeleted'}
+---
+No matched rules or targets found for event.
+<Schema />
+<EventExamples />`;
+
 const generatedUserCreatedEventMarkdownFile = `---
 name: users@UserCreated
 version: '1'
@@ -36,4 +47,5 @@ usercreated-to-hello-world{{usercreated-to-hello-world}}:::rule-- fa:fa-cloud se
 
 export default {
   userCreated: generatedUserCreatedEventMarkdownFile,
+  userDeletedWithNoTargetsOrRules: generatedUserDeletedWithNoRulesOrTargetsMarkdownFile,
 };

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/plugin.spec.ts
@@ -273,7 +273,7 @@ describe('eventcatalog-plugin-generator-amazon-eventbridge', () => {
 
         const { getEventFromCatalog } = utils({ catalogDirectory: process.env.PROJECT_DIR });
 
-        const { raw: eventFile, data: event } = getEventFromCatalog('users@UserDeleted');
+        const { raw: eventFile } = getEventFromCatalog('users@UserDeleted');
 
         // known issue with utils that will default props... replace it for now
         expect(eventFile).toMatchMarkdown(eventSnapshots.userDeletedWithNoTargetsOrRules.replace('owners: []', ''));

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/index.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/index.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { PluginOptions, SchemaTypes } from './types';
 import AWS, { CustomSchema } from './lib/aws';
 
-import { buildMarkdownForEvent } from './markdown';
+import { buildMarkdownForEvent, buildMarkdownForEventWithoutRules } from './markdown';
 
 const buildEventFromEventBridgeSchema = (
   schema: CustomSchema,
@@ -62,7 +62,7 @@ export default async (_: LoadContext, options: PluginOptions) => {
     const { examples, schema, ...eventData } = event;
 
     const detailType = awsSchema?.DetailType;
-    const eventRules = detailType ? rules[detailType] : [];
+    const eventRules = detailType && rules[detailType] ? rules[detailType] : [];
 
     const matchingEventsAlreadyInCatalog = getEventFromCatalog(eventData.name);
 
@@ -79,7 +79,10 @@ export default async (_: LoadContext, options: PluginOptions) => {
       },
       versionExistingEvent: versionEvents && versionChangedFromPreviousEvent,
       useMarkdownContentFromExistingEvent: true,
-      markdownContent: buildMarkdownForEvent({ rules: eventRules, eventBusName, eventName: eventData.name, region }),
+      markdownContent:
+        eventRules.length > 0
+          ? buildMarkdownForEvent({ rules: eventRules, eventBusName, eventName: eventData.name, region })
+          : buildMarkdownForEventWithoutRules(),
     });
   });
 

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/markdown.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/markdown.ts
@@ -21,6 +21,11 @@ ${rule.targets
   .join('')}`;
 
 // eslint-disable-next-line import/prefer-default-export
+export const buildMarkdownForEventWithoutRules = () => `No matched rules or targets found for event.
+<Schema />
+<EventExamples />
+`;
+// eslint-disable-next-line import/prefer-default-export
 export const buildMarkdownForEvent = ({ rules, eventBusName, eventName, region }: any) => `## Matched rules for event
 ${
   rules.length > 0

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/markdown.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/markdown.ts
@@ -20,12 +20,11 @@ ${rule.targets
   )
   .join('')}`;
 
-// eslint-disable-next-line import/prefer-default-export
 export const buildMarkdownForEventWithoutRules = () => `No matched rules or targets found for event.
 <Schema />
 <EventExamples />
 `;
-// eslint-disable-next-line import/prefer-default-export
+
 export const buildMarkdownForEvent = ({ rules, eventBusName, eventName, region }: any) => `## Matched rules for event
 ${
   rules.length > 0


### PR DESCRIPTION
## Motivation

AWS EventBridge events without schemas and targets were breaking in the doc generation.

Now it handles events without targets or events.
