### PR TITLE
fix: issue with long names for services and events rendering incorrectly

### DIFF
--- a/.changeset/serious-brooms-try.md
+++ b/.changeset/serious-brooms-try.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: issue with long names for services and events rendering incorrectly

--- a/packages/eventcatalog/components/Grids/EventGrid.tsx
+++ b/packages/eventcatalog/components/Grids/EventGrid.tsx
@@ -38,7 +38,7 @@ function EventGrid({ events = [], showMermaidDiagrams = false }: EventGridProps)
                 />
                 <div className="w-full border-t border-r border-b border-gray-200 bg-white rounded-r-md ">
                   <div className="p-4 text-sm space-y-2 flex flex-col justify-between h-full">
-                    <div className="text-gray-900 font-bold hover:text-gray-600">
+                    <div className="text-gray-900 font-bold hover:text-gray-600 break-all">
                       {event.name}
                       <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
                         v{event.version}

--- a/packages/eventcatalog/components/Grids/ServiceGrid.tsx
+++ b/packages/eventcatalog/components/Grids/ServiceGrid.tsx
@@ -4,14 +4,16 @@ import Link from 'next/link';
 import { CubeIcon } from '@heroicons/react/outline';
 
 import { Service } from '@eventcatalog/types';
+import Mermaid from '@/components/Mermaid';
 
 import getBackgroundColor from '@/utils/random-bg';
 
 interface ServiceGridProps {
   services: Service[];
+  showMermaidDiagrams?: boolean;
 }
 
-function ServiceGrid({ services = [] }: ServiceGridProps) {
+function ServiceGrid({ services = [], showMermaidDiagrams = false }: ServiceGridProps) {
   return (
     <ul className="mt-3 grid grid-cols-1 gap-5 md:grid-cols-2">
       {services.map((service) => {
@@ -38,6 +40,11 @@ function ServiceGrid({ services = [] }: ServiceGridProps) {
                       )}
                       <div className="text-gray-500 text-xs font-normal mt-2 line-clamp-3">{service.summary}</div>
                     </div>
+                    {showMermaidDiagrams && (
+                      <div className="h-full items-center flex">
+                        <Mermaid source="service" data={service} rootNodeColor={getBackgroundColor(service.name)} />
+                      </div>
+                    )}
                     <div className="flex space-x-4 text-xs pt-2 relative bottom-0 left-0">
                       <div className=" font-medium text-gray-500">
                         <CubeIcon className="h-4 w-4 text-green-400 inline-block mr-2" aria-hidden="true" />

--- a/packages/eventcatalog/components/NotFound/index.tsx
+++ b/packages/eventcatalog/components/NotFound/index.tsx
@@ -16,8 +16,9 @@ export default function Example(props: NotFoundProps) {
           Failed to find {type}
         </p>
         <h1 className="mt-2 text-4xl font-extrabold text-gray-900 tracking-tight sm:text-5xl">Missing Documentation</h1>
-        <p className="mt-2 text-lg font-medium text-gray-700 text-opacity-50">
-          Documentation for {type} <span className="underline">{name}</span> is missing!
+        <p className="mt-2 text-lg font-medium text-gray-700 text-opacity-50 text-center ">
+          Documentation for {type} is missing!
+          <span className="block font-bold text-gray-800 underline break-all max-w-2xl mx-auto py-4">{name}</span>
         </p>
         <p className="mt-4 text-xs text-gray-400">Help the eco-system and add the documentation for others ❤️ </p>
         {editUrl && (
@@ -29,7 +30,7 @@ export default function Example(props: NotFoundProps) {
               rel="noreferrer"
             >
               <DocumentAddIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-              Add <span className="underline px-1">{name}</span> documentation
+              Add missing <span className="underline px-1">{type}</span> documentation
             </a>
           </div>
         )}

--- a/packages/eventcatalog/components/Sidebars/ServiceSidebar.tsx
+++ b/packages/eventcatalog/components/Sidebars/ServiceSidebar.tsx
@@ -42,13 +42,13 @@ function ServiceSidebar({ service }: ServiceSideBarProps) {
           </h2>
           <ul className="mt-2 leading-8">
             {publishes.map((event) => (
-              <li className="inline" key={event.name}>
+              <li className="inline " key={event.name}>
                 <Link href={`/events/${event.name}`}>
                   <a href="#" className="relative inline-flex items-center rounded-full border border-gray-300 px-3 py-0.5">
                     <div className="absolute flex-shrink-0 flex items-center justify-center">
                       <span className="h-1.5 w-1.5 rounded-full bg-indigo-500 animate animate-pulse" aria-hidden="true" />
                     </div>
-                    <div className="ml-3.5 text-sm font-medium text-gray-900">{event.name}</div>
+                    <div className="ml-3.5 text-sm font-medium text-gray-900 truncate max-w-xs">{event.name}</div>
                   </a>
                 </Link>
               </li>
@@ -70,7 +70,7 @@ function ServiceSidebar({ service }: ServiceSideBarProps) {
                     <div className="absolute flex-shrink-0 flex items-center justify-center">
                       <span className="h-1.5 w-1.5 rounded-full bg-green-500  animate animate-pulse" aria-hidden="true" />
                     </div>
-                    <div className="ml-3.5 text-sm font-medium text-gray-900">{event.name}</div>
+                    <div className="ml-3.5 text-sm font-medium text-gray-900 truncate max-w-xs">{event.name}</div>
                   </a>
                 </Link>
               </li>

--- a/packages/eventcatalog/lib/graphs.ts
+++ b/packages/eventcatalog/lib/graphs.ts
@@ -1,11 +1,15 @@
 import type { Event, Service } from '@eventcatalog/types';
 
+const MAX_LENGTH_FOR_NODES = '50';
+
+const truncateNode = (value) => (value.length > MAX_LENGTH_FOR_NODES ? `${value.substring(0, MAX_LENGTH_FOR_NODES)}...` : value);
+
 const buildMermaid = (centerNode, leftNodes, rightNodes, rootNodeColor) => {
   // mermaid does not work with spaces in nodes
   const removeSpacesInNames = (nodes) => nodes.map((node) => node.replace(/ /g, '_'));
-  const lNodes = removeSpacesInNames(leftNodes);
-  const rNodes = removeSpacesInNames(rightNodes);
-  const nodeValue = centerNode.replace(/ /g, '_');
+  const lNodes = removeSpacesInNames(leftNodes).map(truncateNode);
+  const rNodes = removeSpacesInNames(rightNodes).map(truncateNode);
+  const nodeValue = truncateNode(centerNode.replace(/ /g, '_'));
 
   return `flowchart LR
 ${lNodes.map((node) => `${node}:::producer-->${nodeValue}:::event\n`).join('')}

--- a/packages/eventcatalog/pages/events.tsx
+++ b/packages/eventcatalog/pages/events.tsx
@@ -2,8 +2,6 @@ import { Fragment, useState } from 'react';
 import Head from 'next/head';
 import type { Event, Service } from '@eventcatalog/types';
 
-import Link from 'next/link';
-
 import { Menu, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/solid';
 import EventGrid from '@/components/Grids/EventGrid';
@@ -28,7 +26,7 @@ export default function Page({ events, services }: PageProps) {
   const filters = [
     {
       id: 'services',
-      name: 'Services',
+      name: 'Filter by Services',
       options: services.map((service) => ({
         value: service,
         label: service,
@@ -123,19 +121,8 @@ export default function Page({ events, services }: PageProps) {
           <div className="grid grid-cols-4 gap-x-8 gap-y-10">
             {/* Filters */}
             <form className="hidden lg:block">
-              <span className="text-sm font-bold text-gray-900 mb-4 block">Events</span>
-              <ul className=" text-sm text-gray-600 space-y-4 pb-6 border-b border-gray-200 items-stretch">
-                {events.map((event) => (
-                  <li key={event.name}>
-                    <Link href={`/events/${event.name}`}>
-                      <a>{event.name}</a>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-
               {filters.map((section: any) => (
-                <div key={section.id} className="border-b border-gray-200 py-6">
+                <div key={section.id} className="border-b border-gray-200 pb-6">
                   <h3 className="-my-3 flow-root">
                     <div className="py-3 bg-white w-full flex items-center justify-between text-sm text-gray-400 hover:text-gray-500">
                       <span className="font-medium text-gray-900">{section.name}</span>

--- a/packages/eventcatalog/pages/overview.tsx
+++ b/packages/eventcatalog/pages/overview.tsx
@@ -12,15 +12,18 @@ function NodeElement({ node: { id } }: { node: { id: string } }) {
   return <div className={`text-sm text-center p-1 rounded-md `}>{id}</div>;
 }
 
+const MAX_LENGTH_FOR_NODES = 30;
+const truncateNode = (value) => (value.length > MAX_LENGTH_FOR_NODES ? `${value.substring(0, MAX_LENGTH_FOR_NODES)}...` : value);
+
 const graph = ({ events, services }) => {
-  const eventNodes = events.map(({ name: event }) => ({ id: event, group: 1, type: 'event' }));
-  const serviceNodes = services.map((service) => ({ id: service, group: 2, type: 'service' }));
+  const eventNodes = events.map(({ name: event }) => ({ id: truncateNode(event), group: 1, type: 'event' }));
+  const serviceNodes = services.map((service) => ({ id: truncateNode(service), group: 2, type: 'service' }));
 
   // Create all links
   const links = events.reduce((nodes, event) => {
     const { consumers = [], producers = [], name } = event;
-    const consumerNodes = consumers.map((consumer) => ({ source: name, target: consumer }));
-    const producerNodes = producers.map((producer) => ({ source: producer, target: name }));
+    const consumerNodes = consumers.map((consumer) => ({ source: truncateNode(name), target: truncateNode(consumer) }));
+    const producerNodes = producers.map((producer) => ({ source: truncateNode(producer), target: truncateNode(name) }));
     return nodes.concat(consumerNodes).concat(producerNodes);
   }, []);
 

--- a/packages/eventcatalog/pages/services.tsx
+++ b/packages/eventcatalog/pages/services.tsx
@@ -1,8 +1,6 @@
-import { Fragment } from 'react';
+import { Fragment, useState } from 'react';
 import Head from 'next/head';
 import { Service } from '@eventcatalog/types';
-
-import Link from 'next/link';
 
 import { Menu, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/solid';
@@ -24,6 +22,8 @@ export interface PageProps {
 }
 
 export default function Page({ services }: PageProps) {
+  const [showMermaidDiagrams, setShowMermaidDiagrams] = useState(false);
+
   return (
     <>
       <Head>
@@ -83,22 +83,35 @@ export default function Page({ services }: PageProps) {
           <div className="grid grid-cols-4 gap-x-8 gap-y-10">
             {/* Filters */}
             <form className="hidden lg:block">
-              <span className="text-sm font-bold text-gray-900 mb-4 block">Services</span>
-              <ul className=" text-sm font-medium text-gray-900 space-y-4 pb-6 border-b border-gray-200 items-stretch">
-                {services.map((service) => (
-                  <li key={service.name}>
-                    <Link href={`/services/${service.name}`}>
-                      <a>{service.name}</a>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
+              <div className="border-b border-gray-200 pb-6">
+                <h3 className="-my-3 flow-root">
+                  <div className="py-3 bg-white w-full flex items-center justify-between text-sm text-gray-400 hover:text-gray-500">
+                    <span className="font-medium text-gray-900">Features</span>
+                  </div>
+                </h3>
+                <div className="pt-6">
+                  <div className="space-y-4">
+                    <div className="flex items-center">
+                      <input
+                        id="show-mermaid"
+                        type="checkbox"
+                        onChange={(e) => setShowMermaidDiagrams(e.target.checked)}
+                        defaultChecked={showMermaidDiagrams}
+                        className="h-4 w-4 border-gray-300 rounded text-gray-600 focus:ring-gray-500"
+                      />
+                      <label htmlFor="show-mermaid" className="ml-3 text-sm text-gray-600">
+                        Show Mermaid Diagrams
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </form>
 
             <div className="col-span-4 lg:col-span-3">
               <div>
                 <h2 className="text-gray-500 text-xs font-medium uppercase tracking-wide">Services</h2>
-                <ServiceGrid services={services} />
+                <ServiceGrid services={services} showMermaidDiagrams={showMermaidDiagrams} />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Motivation

Fix for #100 raised by @otbe.

• Services and Events should render correctly now
• Long names now get truncated on the Graph view and Event/Service pages
• Mermaid diagrams also truncate the names

## Other improvements

• Removed the event and service lists on the event page and service page.

