### PR TITLE
Configure base path

### DIFF
--- a/.changeset/nine-panthers-hide.md
+++ b/.changeset/nine-panthers-hide.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Configure base path

--- a/.changeset/wise-carpets-drop.md
+++ b/.changeset/wise-carpets-drop.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Configure base path

--- a/.changeset/wise-carpets-drop.md
+++ b/.changeset/wise-carpets-drop.md
@@ -1,5 +1,0 @@
----
-"@eventcatalog/core": patch
----
-
-Configure base path

--- a/packages/eventcatalog/components/Header.tsx
+++ b/packages/eventcatalog/components/Header.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import getConfig from 'next/config';
 import { useRouter } from 'next/router';
 import { useConfig } from '@/hooks/EventCatalog';
 
@@ -16,6 +17,8 @@ export default function Example() {
   const { title } = useConfig();
   const router = useRouter();
 
+  const { publicRuntimeConfig: { basePath = '' } = {} } = getConfig();
+
   return (
     <div className="bg-gray-800">
       <div className="max-w-7xl mx-auto  ">
@@ -24,7 +27,7 @@ export default function Example() {
             <div className="flex-shrink-0 flex items-center text-white font-bold">
               <Link href="/events">
                 <a className="flex items-center">
-                  <img alt="logo" className="text-white w-8 inline-block mr-3" src="/logo.svg" />
+                  <img alt="logo" className="text-white w-8 inline-block mr-3" src={`${basePath}/logo.svg`} />
                   <span className="text-xl">{title}</span>
                 </a>
               </Link>

--- a/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
+++ b/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import getConfig from 'next/config';
 import { CubeIcon, DownloadIcon, ExternalLinkIcon } from '@heroicons/react/outline';
 import type { Event } from '@eventcatalog/types';
 import { useUser } from '@/hooks/EventCatalog';
@@ -14,12 +15,13 @@ function EventSideBar({ event, loadedVersion, isOldVersion }: EventSideBarProps)
   const { getUserById } = useUser();
 
   const { name: eventName, owners, producers, consumers, historicVersions, externalLinks, schema } = event;
+  const { publicRuntimeConfig: { basePath = '' } = {} } = getConfig();
 
   const getSchemaDownloadURL = () => {
     if (!schema) return null;
     return isOldVersion
-      ? `/schemas/${eventName}/${loadedVersion}/schema.${schema.extension}`
-      : `/schemas/${eventName}/schema.${schema.extension}`;
+      ? `${basePath}/schemas/${eventName}/${loadedVersion}/schema.${schema.extension}`
+      : `${basePath}/schemas/${eventName}/schema.${schema.extension}`;
   };
 
   return (

--- a/packages/eventcatalog/next.config.js
+++ b/packages/eventcatalog/next.config.js
@@ -1,3 +1,6 @@
+const config = require('./eventcatalog.config');
+
 module.exports = {
   reactStrictMode: true,
+  basePath: config.basePath,
 };

--- a/packages/eventcatalog/next.config.js
+++ b/packages/eventcatalog/next.config.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const config = require('./eventcatalog.config');
 
 module.exports = {

--- a/packages/eventcatalog/next.config.js
+++ b/packages/eventcatalog/next.config.js
@@ -4,4 +4,7 @@ const config = require('./eventcatalog.config');
 module.exports = {
   reactStrictMode: true,
   basePath: config.basePath,
+  publicRuntimeConfig: {
+    basePath: config.basePath,
+  },
 };

--- a/packages/eventcatalog/pages/index.tsx
+++ b/packages/eventcatalog/pages/index.tsx
@@ -1,17 +1,19 @@
 /* This example requires Tailwind CSS v2.0+ */
 
 import Link from 'next/link';
+import getConfig from 'next/config';
 import { useConfig } from '@/hooks/EventCatalog';
 
 export default function Example() {
   const { title, tagline, logo } = useConfig();
 
-  const logoToLoad = logo || { alt: 'EventCatalog Logo', src: '/logo.svg' };
+  const { publicRuntimeConfig: { basePath = '' } = {} } = getConfig();
+  const logoToLoad = logo || { alt: 'EventCatalog Logo', src: `logo.svg` };
 
   return (
     <main className="sm:bg-top md:min-h-screen bg-gradient-to-t from-blue-700  to-gray-800">
       <div className="max-w-7xl mx-auto px-4 py-16 text-center sm:px-6 sm:py-24 lg:px-8 lg:py-48">
-        <img src={logoToLoad.src} alt={logoToLoad.alt} style={{ height: '85px' }} className="mx-auto" />
+        <img src={`${basePath}/${logoToLoad.src}`} alt={logoToLoad.alt} style={{ height: '85px' }} className="mx-auto" />
         <h1 className="mt-2 text-4xl font-extrabold text-white tracking-tight sm:text-5xl">{title}</h1>
         {tagline && <p className="mt-2 text-lg font-medium text-white">{tagline}</p>}
         <div className="mt-5 max-w-md mx-auto sm:flex sm:justify-center md:mt-8">

--- a/website/docs/api/eventcatalog.config.js.md
+++ b/website/docs/api/eventcatalog.config.js.md
@@ -132,6 +132,6 @@ Set the `basePath` in order to be able to deploy the eventcatalog under a sub-pa
 
 ```js title="eventcatalog.config.js"
 module.exports = {
-  basePath: 'my-catalog',
+  basePath: '/my-catalog',
 };
 ```

--- a/website/docs/api/eventcatalog.config.js.md
+++ b/website/docs/api/eventcatalog.config.js.md
@@ -125,3 +125,13 @@ module.exports = {
   ],
 };
 ```
+
+### `basePath` {#basepath}
+
+Set the `basePath` in order to be able to deploy the eventcatalog under a sub-path of the domain.
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  basePath: 'my-catalog',
+};
+```


### PR DESCRIPTION
## Motivation
Merging this PR enables the eventcatalog user to specify the basePath of the deployment.
Right now we're able to build a static export and deploy it to `example.com` but its not easy to deploy it to `exmaple.com/my-catalog`.

After the merge you can add `basePath` to your `eventcatalog.config.js` and next will pick it up properly.

I think (!) its safe to assume that every way of building the eventcatalog will result in `eventcatalog.config.js` file being copied next to `next.config.js`. At least thats what I observed during testing this change in this repo and in my local eventcatalog.

### Have you read the [Contributing Guidelines on pull requests]
yes
