### PR TITLE
feat: Hide owners section if the events has no owners defined

### DIFF
--- a/.changeset/pink-crabs-attend.md
+++ b/.changeset/pink-crabs-attend.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat: Hide owners section if the events has owners defined

--- a/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
+++ b/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
@@ -142,31 +142,31 @@ function EventSideBar({ event, loadedVersion, isOldVersion }: EventSideBarProps)
         </div>
       </div> */}
       {owners && owners.length > 0 && (
-      <div className="border-t border-gray-200 py-6 space-y-8">
-        <div>
-          <h2 className="text-sm font-medium text-gray-500">Event Owners</h2>
-          <ul className="mt-4 leading-8 space-y-2">
-            {owners.map((id) => {
-              const user = getUserById(id);
+        <div className="border-t border-gray-200 py-6 space-y-8">
+          <div>
+            <h2 className="text-sm font-medium text-gray-500">Event Owners</h2>
+            <ul className="mt-4 leading-8 space-y-2">
+              {owners.map((id) => {
+                const user = getUserById(id);
 
-              if (!user) return null;
+                if (!user) return null;
 
-              return (
-                <li className="flex justify-start" key={id}>
-                  <Link href={`/users/${id}`}>
-                    <a className="flex items-center space-x-3">
-                      <div className="flex-shrink-0">
-                        <img className="h-5 w-5 rounded-full" src={user.avatarUrl} alt="" />
-                      </div>
-                      <div className="text-sm font-medium text-gray-900">{user.name}</div>
-                    </a>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
+                return (
+                  <li className="flex justify-start" key={id}>
+                    <Link href={`/users/${id}`}>
+                      <a className="flex items-center space-x-3">
+                        <div className="flex-shrink-0">
+                          <img className="h-5 w-5 rounded-full" src={user.avatarUrl} alt="" />
+                        </div>
+                        <div className="text-sm font-medium text-gray-900">{user.name}</div>
+                      </a>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
         </div>
-      </div>
       )}
       <div className="border-t border-gray-200 py-6 space-y-1">
         {schema && (

--- a/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
+++ b/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
@@ -141,6 +141,7 @@ function EventSideBar({ event, loadedVersion, isOldVersion }: EventSideBarProps)
           </ul>
         </div>
       </div> */}
+      {owners && owners.length > 0 && (
       <div className="border-t border-gray-200 py-6 space-y-8">
         <div>
           <h2 className="text-sm font-medium text-gray-500">Event Owners</h2>
@@ -166,6 +167,7 @@ function EventSideBar({ event, loadedVersion, isOldVersion }: EventSideBarProps)
           </ul>
         </div>
       </div>
+      )}
       <div className="border-t border-gray-200 py-6 space-y-1">
         {schema && (
           <a


### PR DESCRIPTION
## Motivation

The "owners" property on events is optional.

So if the event frontmatter would not have any "owners" defined, you would still see the header & section (see before screenshot). The PR checks if the "owners" are set and if not hides the section.

Before:
![2022-01-26 at 14 03 59](https://user-images.githubusercontent.com/952446/151167889-83932bd4-16e7-4ac1-869a-f81004c57707.png)

After:
![2022-01-26 at 14 03 06](https://user-images.githubusercontent.com/952446/151167772-ac8c8292-80b2-429a-952b-bf612ad14737.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
yes