### PR TITLE
feat: asyncapi-plugin Insert external links to the AsyncAPI docs

### DIFF
--- a/.changeset/dirty-timers-fail.md
+++ b/.changeset/dirty-timers-fail.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/plugin-doc-generator-asyncapi": patch
+---
+
+feat: asyncapi-plugin Insert external links to the AsyncAPI docs

--- a/packages/eventcatalog-plugin-generator-asyncapi/README.md
+++ b/packages/eventcatalog-plugin-generator-asyncapi/README.md
@@ -13,13 +13,13 @@ You can test and run this plugin locally, by cloning the project.
 First build all the projects
 
 ```sh
-npm run install && npm run build
+npm install && npm run build
 ```
 
 Then you can run 
 
 ```sh
-"PROJECT_DIR={outputForCatalog} node packages/eventcatalog-plugin-generator-asyncapi/scripts/generate-catalog-with-plugin.js`
+"PROJECT_DIR={outputForCatalog} node packages/eventcatalog-plugin-generator-asyncapi/scripts/generate-catalog-with-plugin.js
 ```
 
 This will run the build of the plugin and generate an eventcatalog from an AsyncAPI file (found in examples).

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
@@ -295,7 +295,7 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
                   - 'Account Service'
               consumers: []
               externalLinks:
-                  - {label: UserSignedUp, href: 'https://eventcatalog.dev/events#message-UserSignedUp'}
+                  - {label: 'View event in AsyncAPI', url: 'https://eventcatalog.dev/events#message-UserSignedUp'}
             ---
 
             <Mermaid />

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
@@ -259,7 +259,7 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
         it('when includeLinkToAsyncAPIDoc is set, an external link will be added in the event', async () => {
           const options: AsyncAPIPluginOptions = {
             pathToSpec: path.join(__dirname, './assets/valid-asyncapi.yml'),
-            includeLinkToAsyncAPIDoc: 'https://eventcatalog.dev/events',
+            externalAsyncAPIUrl: 'https://eventcatalog.dev/events',
           };
 
           const oldEvent = {

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
@@ -73,7 +73,7 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
       await expect(plugin(pluginContext, options)).rejects.toThrow('There were errors validating the AsyncAPI document.');
     });
 
-    it('succesfully takes a valid asyncapi file and creates the expected services and events markdown files from it', async () => {
+    it('successfully takes a valid asyncapi file and creates the expected services and events markdown files from it', async () => {
       const options: AsyncAPIPluginOptions = {
         pathToSpec: path.join(__dirname, './assets/valid-asyncapi.yml'),
       };
@@ -96,6 +96,7 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
           producers:
               - 'Account Service'
           consumers: []
+          externalLinks: []
         ---
 
         <Mermaid />
@@ -155,6 +156,7 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
               producers:
                   - 'Account Service'
               consumers: []
+              externalLinks: []
             ---
 
             <Mermaid />
@@ -197,6 +199,7 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
               producers:
                   - 'Account Service'
               consumers: []
+              externalLinks: []
             ---
             # Content that already exists
             `);
@@ -243,6 +246,56 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
               producers:
                   - 'Account Service'
               consumers: []
+              externalLinks: []
+            ---
+
+            <Mermaid />
+            <Schema />
+            `);
+        });
+      });
+
+      describe('includeLinkToAsyncAPIDoc', () => {
+        it('when includeLinkToAsyncAPIDoc is set, an external link will be added in the event', async () => {
+          const options: AsyncAPIPluginOptions = {
+            pathToSpec: path.join(__dirname, './assets/valid-asyncapi.yml'),
+            includeLinkToAsyncAPIDoc: 'https://eventcatalog.dev/events',
+          };
+
+          const oldEvent = {
+            name: 'UserSignedUp',
+            version: '0.0.1',
+            summary: 'Old example of an event that should be versioned',
+            producers: ['Service A'],
+            consumers: ['Service B'],
+            owners: ['dBoyne'],
+          };
+
+          const { writeEventToCatalog } = utils({ catalogDirectory: process.env.PROJECT_DIR });
+          const { path: eventPath } = await writeEventToCatalog(oldEvent, {
+            schema: { extension: 'json', fileContent: 'hello' },
+          });
+
+          // run plugin
+          await plugin(pluginContext, options);
+
+          const { getEventFromCatalog } = utils({ catalogDirectory: process.env.PROJECT_DIR });
+          const { raw: eventFile } = getEventFromCatalog('UserSignedUp');
+
+          // Check the file has been created
+          expect(fs.existsSync(path.join(eventPath, 'index.md'))).toEqual(true);
+          expect(fs.existsSync(path.join(eventPath, 'schema.json'))).toEqual(true);
+
+          expect(eventFile).toMatchMarkdown(`
+            ---
+              name: UserSignedUp
+              summary: null
+              version: 1.0.0
+              producers:
+                  - 'Account Service'
+              consumers: []
+              externalLinks:
+                  - {label: UserSignedUp, href: 'https://eventcatalog.dev/events#message-UserSignedUp'}
             ---
 
             <Mermaid />

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
@@ -12,7 +12,7 @@ const getServiceFromAsyncDoc = (doc: AsyncAPIDocument): Service => ({
 });
 
 const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument, options: AsyncAPIPluginOptions): Event[] => {
-  const { includeLinkToAsyncAPIDoc } = options;
+  const { externalAsyncAPIUrl } = options;
 
   const channels = doc.channels();
   return Object.keys(channels).reduce((data: any, channelName) => {
@@ -28,7 +28,7 @@ const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument, options: AsyncAPIPlugin
       const schema = message.originalPayload();
       const externalLink = {
         label: `View event in AsyncAPI`,
-        url: `${includeLinkToAsyncAPIDoc}#message-${messageName}`,
+        url: `${externalAsyncAPIUrl}#message-${messageName}`,
       };
 
       return {
@@ -37,7 +37,7 @@ const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument, options: AsyncAPIPlugin
         version: doc.info().version(),
         producers: operation === 'subscribe' ? [service] : [],
         consumers: operation === 'publish' ? [service] : [],
-        externalLinks: includeLinkToAsyncAPIDoc ? [externalLink] : [],
+        externalLinks: externalAsyncAPIUrl ? [externalLink] : [],
         schema: schema ? JSON.stringify(schema, null, 4) : '',
       };
     });

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
@@ -11,7 +11,9 @@ const getServiceFromAsyncDoc = (doc: AsyncAPIDocument): Service => ({
   summary: doc.info().description() || '',
 });
 
-const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument): Event[] => {
+const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument, options: AsyncAPIPluginOptions): Event[] => {
+  const { includeLinkToAsyncAPIDoc } = options;
+
   const channels = doc.channels();
   return Object.keys(channels).reduce((data: any, channelName) => {
     const service = doc.info().title();
@@ -24,6 +26,10 @@ const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument): Event[] => {
     const eventsFromMessages = messages.map((message) => {
       const messageName = message.name() || message.extension('x-parser-message-name');
       const schema = message.originalPayload();
+      const externalLink = {
+        label: messageName,
+        href: `${includeLinkToAsyncAPIDoc}#message-${messageName}`,
+      };
 
       return {
         name: messageName,
@@ -31,6 +37,7 @@ const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument): Event[] => {
         version: doc.info().version(),
         producers: operation === 'subscribe' ? [service] : [],
         consumers: operation === 'publish' ? [service] : [],
+        externalLinks: includeLinkToAsyncAPIDoc ? [externalLink]: [],
         schema: schema ? JSON.stringify(schema, null, 4) : '',
       };
     });
@@ -58,7 +65,7 @@ export default async (context: LoadContext, options: AsyncAPIPluginOptions) => {
   const doc = await parse(asyncAPIFile);
 
   const service = getServiceFromAsyncDoc(doc);
-  const events = getAllEventsFromAsyncDoc(doc);
+  const events = getAllEventsFromAsyncDoc(doc, options);
 
   if (!process.env.PROJECT_DIR) {
     throw new Error('Please provide catalog url (env variable PROJECT_DIR)');
@@ -86,5 +93,5 @@ export default async (context: LoadContext, options: AsyncAPIPluginOptions) => {
   // write all events to folders
   Promise.all(eventFiles);
 
-  console.log(chalk.green(`Succesfully parsed AsyncAPI file. Generated ${events.length} events and 1 service`));
+  console.log(chalk.green(`Successfully parsed AsyncAPI file. Generated ${events.length} events and 1 service`));
 };

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
@@ -27,8 +27,8 @@ const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument, options: AsyncAPIPlugin
       const messageName = message.name() || message.extension('x-parser-message-name');
       const schema = message.originalPayload();
       const externalLink = {
-        label: messageName,
-        href: `${includeLinkToAsyncAPIDoc}#message-${messageName}`,
+        label: `View event in AsyncAPI`,
+        url: `${includeLinkToAsyncAPIDoc}#message-${messageName}`,
       };
 
       return {

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
@@ -37,7 +37,7 @@ const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument, options: AsyncAPIPlugin
         version: doc.info().version(),
         producers: operation === 'subscribe' ? [service] : [],
         consumers: operation === 'publish' ? [service] : [],
-        externalLinks: includeLinkToAsyncAPIDoc ? [externalLink]: [],
+        externalLinks: includeLinkToAsyncAPIDoc ? [externalLink] : [],
         schema: schema ? JSON.stringify(schema, null, 4) : '',
       };
     });

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
@@ -1,4 +1,5 @@
 export type AsyncAPIPluginOptions = {
   pathToSpec: string;
   versionEvents?: boolean;
+  includeLinkToAsyncAPIDoc?: string;
 };

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
@@ -1,5 +1,5 @@
 export type AsyncAPIPluginOptions = {
   pathToSpec: string;
   versionEvents?: boolean;
-  includeLinkToAsyncAPIDoc?: string;
+  externalAsyncAPIUrl?: string;
 };

--- a/website/docs/api/plugins/plugin-doc-generator-asyncapi.md
+++ b/website/docs/api/plugins/plugin-doc-generator-asyncapi.md
@@ -45,7 +45,7 @@ npm install --save @eventcatalog/plugin-doc-generator-asyncapi
 | --- | --- | --- | --- |
 | `pathToSpec` | `string` | `'/asyncapi.yml'` | Path to AsyncAPI document. |
 | `versionEvents` | `boolean` | `true` | When the plugin runs and it finds matching events in the catalog, it will version the events before creating the new documentation. |
-| `includeLinkToAsyncAPIDoc` | `string` | `https://asyncapi.com` | When a AsyncAPI base url is set the, a external link to the AsyncAPI message documentation will be added to each event. |
+| `externalAsyncAPIUrl` | `string` | `` | When a AsyncAPI base url is set the, a external link to the AsyncAPI message documentation will be added to each event. |
 
 </APITable>
 

--- a/website/docs/api/plugins/plugin-doc-generator-asyncapi.md
+++ b/website/docs/api/plugins/plugin-doc-generator-asyncapi.md
@@ -45,6 +45,7 @@ npm install --save @eventcatalog/plugin-doc-generator-asyncapi
 | --- | --- | --- | --- |
 | `pathToSpec` | `string` | `'/asyncapi.yml'` | Path to AsyncAPI document. |
 | `versionEvents` | `boolean` | `true` | When the plugin runs and it finds matching events in the catalog, it will version the events before creating the new documentation. |
+| `includeLinkToAsyncAPIDoc` | `string` | `https://asyncapi.com` | When a AsyncAPI base url is set the, a external link to the AsyncAPI message documentation will be added to each event. |
 
 </APITable>
 


### PR DESCRIPTION
## Motivation

Since EventCatalog generates Events based on the AsyncAPI, it is handy to reference the public AsyncAPI documentation on the Event details page as an external link. This will reduce the workload of adding the links manually.

Result:
![2022-01-26 at 15 48 50](https://user-images.githubusercontent.com/952446/151185444-e8eabbd0-39c2-4580-aa51-1a9bca03a2c7.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?
Yes
