### PR TITLE
bug: fixed issue with purging css from the admonition component

### DIFF
--- a/.changeset/wise-ducks-knock.md
+++ b/.changeset/wise-ducks-knock.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+bug: fixed issue with purging css from the admonition component

--- a/packages/eventcatalog/tailwind.config.js
+++ b/packages/eventcatalog/tailwind.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  purge: [],
   darkMode: false,
   theme: {
     extend: {},
@@ -7,6 +6,9 @@ module.exports = {
   variants: {
     extend: {},
   },
-  purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  purge: {
+    content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+    safelist: ['bg-red-50', 'bg-yellow-50', 'bg-indigo-50', 'text-red-400', 'text-yellow-400', 'text-indigo-400'],
+  },
   plugins: [require('@tailwindcss/typography'), require('@tailwindcss/forms'), require('@tailwindcss/line-clamp')],
 };


### PR DESCRIPTION
## Motivation

Fix for #118

Using tailwind [safelist](https://tailwindcss.com/docs/content-configuration)

Tried using the regex they recommend but it was doubling the CSS output to around 60kb... so using these strings (like in the PR) it keeps the size of the CSS down. This change adds 1kb to the CSS output (30kb total now).

