### PR TITLE
fix: build directory is now copied over to the users proejct dir

### DIFF
--- a/.changeset/gentle-pants-teach.md
+++ b/.changeset/gentle-pants-teach.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: build directory is now copied over to the users proejct dir

--- a/packages/eventcatalog/bin/eventcatalog.js
+++ b/packages/eventcatalog/bin/eventcatalog.js
@@ -41,7 +41,7 @@ cli
 
 cli
   .command('build [siteDir]')
-  .description('Start the development server.')
+  .description('Build eventcatalog project.')
   .action(() => {
     if (!fs.existsSync(eventCatalogLibDir)) {
       copyCoreApplicationCodeIntoUsersProjectDir();
@@ -64,6 +64,7 @@ cli
 
     // everything is built make sure its back in the users project directory
     fs.copySync(path.join(eventCatalogLibDir, '.next'), path.join(projectDIR, '.next'));
+    fs.copySync(path.join(eventCatalogLibDir, 'out'), path.join(projectDIR, 'out'));
   });
 
 cli


### PR DESCRIPTION
## Motivation

Fix for #131, moving the out directory back to the users directory on build.
