### PR TITLE
fix: adding types for create app and also ignore out dir

### DIFF
--- a/.changeset/olive-windows-pull.md
+++ b/.changeset/olive-windows-pull.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+fix: adding types for create app and also ignore out dir

--- a/packages/create-eventcatalog/create-app.ts
+++ b/packages/create-eventcatalog/create-app.ts
@@ -194,7 +194,7 @@ export async function createApp({
     /**
      * Default devDependencies.
      */
-    const devDependencies = ['@types/react', '@eventcatalog/types'];
+    const devDependencies = ['@types/react', '@eventcatalog/types', '@types/node'];
     /**
      * TypeScript projects will have type definitions and other devDependencies.
      */

--- a/packages/create-eventcatalog/templates/default/gitignore
+++ b/packages/create-eventcatalog/templates/default/gitignore
@@ -7,6 +7,7 @@
 
 # Generated files
 .next
+out
 
 
 # Misc


### PR DESCRIPTION
## Motivation

Adding missing types for `node/types` also `out` dir is now ignored in users directory.

