### PR TITLE
fix: header link now goes to landing page

### DIFF
--- a/.changeset/great-lobsters-admire.md
+++ b/.changeset/great-lobsters-admire.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: header link now goes to landing page

--- a/packages/eventcatalog/components/Header.tsx
+++ b/packages/eventcatalog/components/Header.tsx
@@ -25,7 +25,7 @@ export default function Example() {
         <div className="relative flex items-center justify-between h-16">
           <div className="flex-1 flex items-center justify-center sm:items-stretch sm:justify-start">
             <div className="flex-shrink-0 flex items-center text-white font-bold">
-              <Link href="/events">
+              <Link href="/">
                 <a className="flex items-center">
                   <img alt="logo" className="text-white w-8 inline-block mr-3" src={`${basePath}/logo.svg`} />
                   <span className="text-xl">{title}</span>


### PR DESCRIPTION
## Motivation

Header now goes to to the homepage rather than /events page.


