### PR TITLE
feat: configure homepageLink

### DIFF
--- a/.changeset/polite-feet-compare.md
+++ b/.changeset/polite-feet-compare.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/types": patch
+"@eventcatalog/core": patch
+---
+
+feat: add new eventcatalog config property to set homepage url

--- a/examples/basic/eventcatalog.config.js
+++ b/examples/basic/eventcatalog.config.js
@@ -3,7 +3,6 @@ module.exports = {
   tagline: 'Discover, Explore and Document your Event Driven Architectures',
   organizationName: 'Your Company',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
-  homepageLink: 'https://eventcatalog.dev/',
   trailingSlash: true,
   logo: {
     alt: 'EventCatalog Logo',

--- a/examples/basic/eventcatalog.config.js
+++ b/examples/basic/eventcatalog.config.js
@@ -3,6 +3,7 @@ module.exports = {
   tagline: 'Discover, Explore and Document your Event Driven Architectures',
   organizationName: 'Your Company',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
+  homepageLink: 'https://eventcatalog.dev/',
   logo: {
     alt: 'EventCatalog Logo',
     src: 'logo.svg',

--- a/packages/eventcatalog-types/src/index.d.ts
+++ b/packages/eventcatalog-types/src/index.d.ts
@@ -70,7 +70,7 @@ export interface EventCataLogConfig {
   users?: User[];
   generators?: PluginConfig[] | [] | any;
   footerLinks?: Link[];
-  homepageLink?: Link;
+  homepageLink?: string;
 }
 
 export type LoadContext = {

--- a/packages/eventcatalog-types/src/index.d.ts
+++ b/packages/eventcatalog-types/src/index.d.ts
@@ -70,6 +70,7 @@ export interface EventCataLogConfig {
   users?: User[];
   generators?: PluginConfig[] | [] | any;
   footerLinks?: Link[];
+  homepageLink?: Link;
 }
 
 export type LoadContext = {

--- a/packages/eventcatalog/components/Header.tsx
+++ b/packages/eventcatalog/components/Header.tsx
@@ -14,7 +14,7 @@ function classNames(...classes) {
 }
 
 export default function Example() {
-  const { title } = useConfig();
+  const { title, homepageLink } = useConfig();
   const router = useRouter();
 
   const { publicRuntimeConfig: { basePath = '' } = {} } = getConfig();
@@ -25,12 +25,20 @@ export default function Example() {
         <div className="relative flex items-center justify-between h-16">
           <div className="flex-1 flex items-center justify-center sm:items-stretch sm:justify-start">
             <div className="flex-shrink-0 flex items-center text-white font-bold">
-              <Link href="/">
-                <a className="flex items-center">
+              {!homepageLink && (
+                <Link href="/">
+                  <a className="flex items-center">
+                    <img alt="logo" className="text-white w-8 inline-block mr-3" src={`${basePath}/logo.svg`} />
+                    <span className="text-xl">{title}</span>
+                  </a>
+                </Link>
+              )}
+              {homepageLink && (
+                <a href={`${homepageLink}`} className="flex items-center">
                   <img alt="logo" className="text-white w-8 inline-block mr-3" src={`${basePath}/logo.svg`} />
                   <span className="text-xl">{title}</span>
                 </a>
-              </Link>
+              )}
             </div>
           </div>
           <div className="hidden sm:block sm:ml-6">

--- a/packages/eventcatalog/components/Header.tsx
+++ b/packages/eventcatalog/components/Header.tsx
@@ -34,7 +34,7 @@ export default function Example() {
                 </Link>
               )}
               {homepageLink && (
-                <a href={`${homepageLink}`} className="flex items-center">
+                <a href={homepageLink} className="flex items-center">
                   <img alt="logo" className="text-white w-8 inline-block mr-3" src={`${basePath}/logo.svg`} />
                   <span className="text-xl">{title}</span>
                 </a>

--- a/website/docs/api/eventcatalog.config.js.md
+++ b/website/docs/api/eventcatalog.config.js.md
@@ -79,6 +79,18 @@ module.exports = {
 };
 ```
 
+### `homepageLink` {#homepageLink}
+
+- Type: `string`
+
+URL used when people want to link the logo & title in the top navigation to the homepage of a website.
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  homepageLink: 'https://eventcatalog.dev',
+};
+```
+
 ### `users` {#users}
 
 Add user information here. You can reference these inside your Event and Service markdown files.


### PR DESCRIPTION
## Motivation

The event catalog can be part of a bigger developer portal. It is a common UX that clicking the logo in the top navigation returns the visitor to the homage page of the website. The configuration is optional, If not set the user will navigate to the root of the Event Catalog.

![2022-01-28 at 14 45 13](https://user-images.githubusercontent.com/952446/151557468-126801ab-3982-4a19-91f0-a400dc18107d.png)
![2022-01-28 at 14 45 49@2x](https://user-images.githubusercontent.com/952446/151557552-19bb944b-0124-4100-b874-cc02d5d9fcdc.png)


### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?
yes
