### PR TITLE
feat: configure favicon and set page title, description

### DIFF
--- a/examples/basic/eventcatalog.config.js
+++ b/examples/basic/eventcatalog.config.js
@@ -2,6 +2,7 @@ module.exports = {
   title: 'EventCatalog',
   tagline: 'Discover, Explore and Document your Event Driven Architectures',
   organizationName: 'Your Company',
+  favicon: 'https://www.eventcatalog.dev/img/favicon.ico',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   logo: {
     alt: 'EventCatalog Logo',

--- a/packages/eventcatalog-types/src/index.d.ts
+++ b/packages/eventcatalog-types/src/index.d.ts
@@ -66,6 +66,7 @@ export interface EventCataLogConfig {
   tagline?: string;
   editUrl?: string;
   organizationName: string;
+  favicon?: string;
   logo?: { alt: string; src: string };
   users?: User[];
   generators?: PluginConfig[] | [] | any;

--- a/packages/eventcatalog/pages/_app.tsx
+++ b/packages/eventcatalog/pages/_app.tsx
@@ -3,40 +3,44 @@ import { AppProps } from 'next/app';
 import Head from 'next/head';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
-import { EventCatalogContextProvider } from '@/hooks/EventCatalog';
+import { EventCatalogContextProvider, useConfig } from '@/hooks/EventCatalog';
 
-export default ({ Component, pageProps }: AppProps) => (
-  <EventCatalogContextProvider>
-    <Head>
-      <title>EventCatalog</title>
-      <script src="//unpkg.com/three" />
-      <script src="//unpkg.com/three/examples/js/renderers/CSS2DRenderer.js" />
+export default function Page({ Component, pageProps }: AppProps) {
+  const { title, tagline, favicon = 'favicon.ico' } = useConfig();
 
-      <link rel="stylesheet" href="https://cdn.bootcss.com/font-awesome/4.7.0/css/font-awesome.css" />
+  return (
+    <EventCatalogContextProvider>
+      <Head>
+        <title>{title}</title>
+        <script src="//unpkg.com/three" />
+        <script src="//unpkg.com/three/examples/js/renderers/CSS2DRenderer.js" />
 
-      <meta
-        name="description"
-        content="An open source project to Discover, Explore and Document your Event Driven Architectures."
-      />
-      <meta property="og:url" content="https://eventcatalog.dev/" />
-      <meta property="og:type" content="website" />
-      <meta property="og:title" content="EventCatalog | Discover, Explore and Document your Event Driven Architectures." />
-      <meta
-        property="og:description"
-        content="An open source tool powered by markdown to document your Event Driven Architecture."
-      />
-      <meta property="og:image" content="https://eventcatalog.dev/img/opengraph.png" />
-      <meta property="og:image:alt" content="EventCatalog | Discover, Explore and Document your Event Driven Architectures." />
-      <meta property="og:image:width" content="1200" />
-      <meta property="og:image:height" content="600" />
-      <meta property="og:locale" content="en-GB" />
-      <meta name="author" content="David Boyne" />
+        <link rel="stylesheet" href="https://cdn.bootcss.com/font-awesome/4.7.0/css/font-awesome.css" />
 
-      {/* Need to load this before any of the Html2Diff Code */}
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/atom-one-light.min.css" />
-    </Head>
-    <Header />
-    <Component {...pageProps} />
-    <Footer />
-  </EventCatalogContextProvider>
-);
+        <meta name="description" content={`${tagline}`} />
+
+        <link rel="icon" href={`${favicon}`} />
+
+        <meta property="og:url" content="https://eventcatalog.dev/" />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="EventCatalog | Discover, Explore and Document your Event Driven Architectures." />
+        <meta
+          property="og:description"
+          content="An open source tool powered by markdown to document your Event Driven Architecture."
+        />
+        <meta property="og:image" content="https://eventcatalog.dev/img/opengraph.png" />
+        <meta property="og:image:alt" content="EventCatalog | Discover, Explore and Document your Event Driven Architectures." />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="600" />
+        <meta property="og:locale" content="en-GB" />
+        <meta name="author" content="David Boyne" />
+
+        {/* Need to load this before any of the Html2Diff Code */}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/atom-one-light.min.css" />
+      </Head>
+      <Header />
+      <Component {...pageProps} />
+      <Footer />
+    </EventCatalogContextProvider>
+  );
+}

--- a/website/docs/api/eventcatalog.config.js.md
+++ b/website/docs/api/eventcatalog.config.js.md
@@ -79,6 +79,21 @@ module.exports = {
 };
 ```
 
+
+### `favicon` {#favicon}
+
+Path or URL to your custom favicon.
+
+Example, if your favicon is in `public/favicon.png`:
+
+_EventCatalog will look inside the public directory, no need to put this into your string value_
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  favicon: 'https://www.eventcatalog.dev/img/favicon.ico'
+};
+```
+
 ### `users` {#users}
 
 Add user information here. You can reference these inside your Event and Service markdown files.


### PR DESCRIPTION
## Motivation

Linked to #129

Provide the option to set the favicon of the Event Catalog + use the title & tagline from the `eventcatalog.config.js` instead of the static defined text.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?
yes
