### PR TITLE
bug: use title when setting page title

### DIFF
--- a/.changeset/tiny-foxes-mate.md
+++ b/.changeset/tiny-foxes-mate.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+bug: use title when setting page title

--- a/packages/eventcatalog/pages/events.tsx
+++ b/packages/eventcatalog/pages/events.tsx
@@ -7,6 +7,7 @@ import { Menu, Transition } from '@headlessui/react';
 import { ChevronDownIcon, SearchIcon } from '@heroicons/react/solid';
 import EventGrid from '@/components/Grids/EventGrid';
 import { getAllEvents, getUniqueServicesNamesFromEvents } from '@/lib/events';
+import { useConfig } from '@/hooks/EventCatalog';
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
@@ -89,11 +90,12 @@ export default function Page({ events, services }: PageProps) {
   );
 
   const filtersApplied = !!searchFilter || selectedFilters.services.length > 0;
+  const { title } = useConfig();
 
   return (
     <>
       <Head>
-        <title>EventCatalog - All Events</title>
+        <title>{title} - All Events</title>
       </Head>
       <main className="max-w-7xl mx-auto min-h-screen px-4 md:px-0">
         <div className="relative z-10 flex items-baseline justify-between pt-8 pb-6 border-b border-gray-200">

--- a/packages/eventcatalog/pages/events/[name].tsx
+++ b/packages/eventcatalog/pages/events/[name].tsx
@@ -15,7 +15,7 @@ import BreadCrumbs from '@/components/BreadCrumbs';
 import SyntaxHighlighter from '@/components/SyntaxHighlighter';
 
 import { getAllEvents, getEventByName } from '@/lib/events';
-import { useUrl } from '@/hooks/EventCatalog';
+import { useConfig, useUrl } from '@/hooks/EventCatalog';
 
 import { MarkdownFile } from '@/types/index';
 
@@ -66,6 +66,7 @@ export const getComponents = ({ event, schema, examples }: any) => ({
 
 export default function Events(props: EventsPageProps) {
   const { event, markdown, loadedVersion, notFound } = props;
+  const { title } = useConfig();
   const { getEditUrl, hasEditUrl } = useUrl();
 
   const { name, summary, draft, schema, examples, version } = event;
@@ -86,7 +87,7 @@ export default function Events(props: EventsPageProps) {
     <>
       <Head>
         <title>
-          {name} v{version}
+          {title} - {name} v{version}
         </title>
       </Head>
       <ContentView

--- a/packages/eventcatalog/pages/overview.tsx
+++ b/packages/eventcatalog/pages/overview.tsx
@@ -5,6 +5,7 @@ import Head from 'next/head';
 import dynamic from 'next/dynamic';
 
 import { getAllEvents, getUniqueServicesNamesFromEvents } from '@/lib/events';
+import { useConfig } from '@/hooks/EventCatalog';
 
 const ForceGraph3D = dynamic(() => import('react-force-graph-3d').then((module) => module.default), { ssr: false });
 
@@ -16,6 +17,8 @@ const MAX_LENGTH_FOR_NODES = 30;
 const truncateNode = (value) => (value.length > MAX_LENGTH_FOR_NODES ? `${value.substring(0, MAX_LENGTH_FOR_NODES)}...` : value);
 
 const graph = ({ events, services }) => {
+  const { title } = useConfig();
+
   const eventNodes = events.map(({ name: event }) => ({ id: truncateNode(event), group: 1, type: 'event' }));
   const serviceNodes = services.map((service) => ({ id: truncateNode(service), group: 2, type: 'service' }));
 
@@ -35,10 +38,11 @@ const graph = ({ events, services }) => {
 
   // @ts-ignore
   const extraRenderers = [new window.THREE.CSS2DRenderer()];
+
   return (
     <div className="min-h-screen ">
       <Head>
-        <title>EventCatalog - 3D Node Graph</title>
+        <title>{title} - 3D Node Graph</title>
       </Head>
       <ForceGraph3D
         extraRenderers={extraRenderers}

--- a/packages/eventcatalog/pages/overview.tsx
+++ b/packages/eventcatalog/pages/overview.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import Head from 'next/head';
-
 import dynamic from 'next/dynamic';
-
+import type { Event, Service } from '@eventcatalog/types';
 import { getAllEvents, getUniqueServicesNamesFromEvents } from '@/lib/events';
 import { useConfig } from '@/hooks/EventCatalog';
+
+export interface PageProps {
+  events: Event[];
+  services: Service[];
+}
 
 const ForceGraph3D = dynamic(() => import('react-force-graph-3d').then((module) => module.default), { ssr: false });
 
@@ -16,7 +20,7 @@ function NodeElement({ node: { id } }: { node: { id: string } }) {
 const MAX_LENGTH_FOR_NODES = 30;
 const truncateNode = (value) => (value.length > MAX_LENGTH_FOR_NODES ? `${value.substring(0, MAX_LENGTH_FOR_NODES)}...` : value);
 
-const graph = ({ events, services }) => {
+function Graph({ events, services }: PageProps) {
   const { title } = useConfig();
 
   const eventNodes = events.map(({ name: event }) => ({ id: truncateNode(event), group: 1, type: 'event' }));
@@ -40,7 +44,7 @@ const graph = ({ events, services }) => {
   const extraRenderers = [new window.THREE.CSS2DRenderer()];
 
   return (
-    <div className="min-h-screen ">
+    <div className="min-h-screen">
       <Head>
         <title>{title} - 3D Node Graph</title>
       </Head>
@@ -66,9 +70,9 @@ const graph = ({ events, services }) => {
       />
     </div>
   );
-};
+}
 
-export default graph;
+export default Graph;
 
 export const getStaticProps = () => {
   const events = getAllEvents();

--- a/packages/eventcatalog/pages/services.tsx
+++ b/packages/eventcatalog/pages/services.tsx
@@ -6,6 +6,7 @@ import { Menu, Transition } from '@headlessui/react';
 import { ChevronDownIcon } from '@heroicons/react/solid';
 import ServiceGrid from '@/components/Grids/ServiceGrid';
 import { getAllServices } from '@/lib/services';
+import { useConfig } from '@/hooks/EventCatalog';
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
@@ -23,11 +24,12 @@ export interface PageProps {
 
 export default function Page({ services }: PageProps) {
   const [showMermaidDiagrams, setShowMermaidDiagrams] = useState(false);
+  const { title } = useConfig();
 
   return (
     <>
       <Head>
-        <title>EventCatalog - All Services</title>
+        <title>{title} - All Services</title>
       </Head>
       <main className="max-w-7xl mx-auto md:min-h-screen px-4 md:px-0">
         <div className="relative z-10 flex items-baseline justify-between pt-8 pb-6 border-b border-gray-200">

--- a/packages/eventcatalog/pages/services/[name].tsx
+++ b/packages/eventcatalog/pages/services/[name].tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { MDXRemote } from 'next-mdx-remote';
+
 import { Service } from '@eventcatalog/types';
 import ContentView from '@/components/ContentView';
 import { getAllServices, getServiceByName } from '@/lib/services';
@@ -10,7 +11,7 @@ import ServiceSidebar from '@/components/Sidebars/ServiceSidebar';
 import BreadCrumbs from '@/components/BreadCrumbs';
 import NotFound from '@/components/NotFound';
 import getBackgroundColor from '@/utils/random-bg';
-import { useUrl } from '@/hooks/EventCatalog';
+import { useConfig, useUrl } from '@/hooks/EventCatalog';
 
 import { MarkdownFile } from '@/types/index';
 
@@ -38,6 +39,7 @@ const getComponents = (service) => ({
 
 export default function Services(props: ServicesPageProps) {
   const { service, markdown, notFound } = props;
+  const { title } = useConfig();
   const { getEditUrl, hasEditUrl } = useUrl();
 
   if (notFound)
@@ -58,7 +60,9 @@ export default function Services(props: ServicesPageProps) {
   return (
     <>
       <Head>
-        <title>{name}</title>
+        <title>
+          {title} - {name}
+        </title>
       </Head>
       <ContentView
         title={name}


### PR DESCRIPTION
## Motivation

The page title prefix is currently hardcoded to "EventCatalog", this PR changes the behaviour to use the `title` as prefix like defined in the `eventcatalog.config.js`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
