### PR TITLE
feat: mermaid name and link

### DIFF
--- a/.changeset/beige-trains-glow.md
+++ b/.changeset/beige-trains-glow.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat: mermaid name and link

--- a/packages/eventcatalog/lib/__tests__/graphs.spec.ts
+++ b/packages/eventcatalog/lib/__tests__/graphs.spec.ts
@@ -73,7 +73,7 @@ click Service_2 href "/docs/services/Service 2" "Go to Service 2" _self
 click My_Event href "/docs/events/My Event" "Go to My Event" _self`);
     });
 
-    it('transforms any service name with spaces into _', () => {
+    it('persists the spaces in the service name and renders them with mermaid', () => {
       const event = {
         name: 'My Event',
         version: '0.0.1',

--- a/packages/eventcatalog/lib/__tests__/graphs.spec.ts
+++ b/packages/eventcatalog/lib/__tests__/graphs.spec.ts
@@ -1,5 +1,11 @@
 import { buildMermaidFlowChartForEvent, buildMermaidFlowChartForService } from '../graphs';
 
+jest.mock('next/config', () => () => ({
+  publicRuntimeConfig: {
+    basePath: '/docs',
+  },
+}));
+
 describe('graphs', () => {
   describe('buildMermaidFlowChartForService', () => {
     it('takes a given Service and returns the mermaid code showing relationships between the events it publishes and consumes', () => {
@@ -18,12 +24,22 @@ describe('graphs', () => {
       const result = buildMermaidFlowChartForService(service);
 
       expect(result.trim()).toEqual(`flowchart LR
-My_Event_2:::producer-->My_Service:::event
+
+My_Event[My Event]:::producer-->My_Service[My Service]:::event
 
 classDef event stroke:#2563eb,stroke-width: 4px;
+
 classDef producer stroke:#75d7b6,stroke-width: 2px;
+
 classDef consumer stroke:#818cf8,stroke-width: 2px;
-My_Service:::event-->My_Event:::consumer`);
+
+My_Service[My Service]:::event-->My_Event_2[My Event 2]:::consumer
+
+click My_Event href "/docs/events/My Event" "Go to My Event" _self
+
+click My_Event_2 href "/docs/events/My Event 2" "Go to My Event 2" _self
+
+click My_Service href "/docs/services/My Service" "Go to My Service" _self`);
     });
   });
 
@@ -39,12 +55,22 @@ My_Service:::event-->My_Event:::consumer`);
       const result = buildMermaidFlowChartForEvent(event);
 
       expect(result.trim()).toEqual(`flowchart LR
-Service_1:::producer-->My_Event:::event
+
+Service_1[Service 1]:::producer-->My_Event[My Event]:::event
 
 classDef event stroke:#2563eb,stroke-width: 4px;
+
 classDef producer stroke:#75d7b6,stroke-width: 2px;
+
 classDef consumer stroke:#818cf8,stroke-width: 2px;
-My_Event:::event-->Service_2:::consumer`);
+
+My_Event[My Event]:::event-->Service_2[Service 2]:::consumer
+
+click Service_1 href "/docs/services/Service 1" "Go to Service 1" _self
+
+click Service_2 href "/docs/services/Service 2" "Go to Service 2" _self
+
+click My_Event href "/docs/events/My Event" "Go to My Event" _self`);
     });
 
     it('transforms any service name with spaces into _', () => {
@@ -55,8 +81,8 @@ My_Event:::event-->Service_2:::consumer`);
         consumers: [],
       };
       const result = buildMermaidFlowChartForEvent(event);
-      expect(result).toContain(`Service_1_With_Spaces:::producer-->My_Event:::event`);
-      expect(result).not.toContain(`Service 1 With Spaces`);
+      expect(result).toContain(`Service_1_With_Spaces[Service 1 With Spaces]:::producer-->My_Event[My Event]:::event`);
+      expect(result).not.toContain(`Service 1 With Spaces[`);
     });
   });
 });

--- a/packages/eventcatalog/lib/graphs.ts
+++ b/packages/eventcatalog/lib/graphs.ts
@@ -1,35 +1,82 @@
 import type { Event, Service } from '@eventcatalog/types';
+import getConfig from 'next/config';
 
 const MAX_LENGTH_FOR_NODES = '50';
+const { publicRuntimeConfig: { basePath = '' } = {} } = getConfig();
 
 const truncateNode = (value) => (value.length > MAX_LENGTH_FOR_NODES ? `${value.substring(0, MAX_LENGTH_FOR_NODES)}...` : value);
+const generateLink = (value, type) => (basePath !== '' ? `${basePath}/${type}/${value}` : `/${type}/${value}`);
 
-const buildMermaid = (centerNode, leftNodes, rightNodes, rootNodeColor) => {
-  // mermaid does not work with spaces in nodes
-  const removeSpacesInNames = (nodes) => nodes.map((node) => node.replace(/ /g, '_'));
-  const lNodes = removeSpacesInNames(leftNodes).map(truncateNode);
-  const rNodes = removeSpacesInNames(rightNodes).map(truncateNode);
-  const nodeValue = truncateNode(centerNode.replace(/ /g, '_'));
+/**
+ * Build Mermaid graph output
+ * @param centerNode
+ * @param leftNodes
+ * @param rightNodes
+ * @param rootNodeColor
+ */
+const buildMermaid = (centerNode, leftNodes, rightNodes, rootNodeColor) => `flowchart LR\n
+${leftNodes.map((node) => `${node.id}[${node.name}]:::producer-->${centerNode.id}[${centerNode.name}]:::event\n`).join('')}
+classDef event stroke:${rootNodeColor},stroke-width: 4px;\n
+classDef producer stroke:#75d7b6,stroke-width: 2px;\n
+classDef consumer stroke:#818cf8,stroke-width: 2px;\n
+${rightNodes.map((node) => `${centerNode.id}[${centerNode.name}]:::event-->${node.id}[${node.name}]:::consumer\n`).join('')}
+${leftNodes.map((node) => `click ${node.id} href "${node.link}" "Go to ${node.name}" _self\n`).join('')}
+${rightNodes.map((node) => `click ${node.id} href "${node.link}" "Go to ${node.name}" _self\n`).join('')}
+click ${centerNode.id} href "${centerNode.link}" "Go to ${centerNode.name}" _self\n
+`;
 
-  return `flowchart LR
-${lNodes.map((node) => `${node}:::producer-->${nodeValue}:::event\n`).join('')}
-classDef event stroke:${rootNodeColor},stroke-width: 4px;
-classDef producer stroke:#75d7b6,stroke-width: 2px;
-classDef consumer stroke:#818cf8,stroke-width: 2px;
-${rNodes.map((node) => `${nodeValue}:::event-->${node}:::consumer\n`).join('')}
-  `;
+/**
+ * Builds a graph for a given event
+ * @param {Event} event
+ * @param {string} rootNodeColor of the root node
+ * @returns {string} Mermaid Graph
+ */
+export const buildMermaidFlowChartForEvent = ({ name: eventName, producers, consumers }: Event, rootNodeColor = '#2563eb') => {
+  // Transforms services & event into a graph model
+  const leftNodes = producers.map(truncateNode).map((node) => ({
+    id: node.replace(/ /g, '_'),
+    name: node,
+    link: generateLink(node, 'services'),
+  }));
+  const rightNodes = consumers.map(truncateNode).map((node) => ({
+    id: node.replace(/ /g, '_'),
+    name: node,
+    link: generateLink(node, 'services'),
+  }));
+  const centerNode = {
+    id: truncateNode(eventName.replace(/ /g, '_')),
+    name: eventName,
+    link: generateLink(eventName, 'events'),
+  };
+
+  return buildMermaid(centerNode, leftNodes, rightNodes, rootNodeColor);
 };
 
-export const buildMermaidFlowChartForEvent = ({ name: eventName, producers, consumers }: Event, rootNodeColor = '#2563eb') =>
-  buildMermaid(eventName, producers, consumers, rootNodeColor);
-
+/**
+ * Builds a graph for a given service
+ * @param {Service} service
+ * @param {string} rootNodeColor of the root node
+ * @returns {string} Mermaid Graph
+ */
 export const buildMermaidFlowChartForService = (
   { publishes, subscribes, name: serviceName }: Service,
   rootNodeColor = '#2563eb'
-) =>
-  buildMermaid(
-    serviceName,
-    subscribes.map((s) => s.name),
-    publishes.map((p) => p.name),
-    rootNodeColor
-  );
+) => {
+  // Transforms services & event into a graph model
+  const leftNodes = publishes.map(truncateNode).map((node) => ({
+    id: node.name.replace(/ /g, '_'),
+    name: node.name,
+    link: generateLink(node.name, 'events'),
+  }));
+  const rightNodes = subscribes.map(truncateNode).map((node) => ({
+    id: node.name.replace(/ /g, '_'),
+    name: node.name,
+    link: generateLink(node.name, 'events'),
+  }));
+  const centerNode = {
+    id: truncateNode(serviceName.replace(/ /g, '_')),
+    name: serviceName,
+    link: generateLink(serviceName, 'services'),
+  };
+  return buildMermaid(centerNode, leftNodes, rightNodes, rootNodeColor);
+};


### PR DESCRIPTION
## Motivation

Event Catalog generated a nicely looking Mermaid schema of the events/services <> producers/consumers mode.
The name of the events/services was shown with an _ when there were spaces and the nodes were not clickable.

The PR introduces that the name will be displayed, even with spaces AND that the nodes are clickable, navigating them to the event/service page of the node.

Before:
![2022-01-28 at 20 19 36](https://user-images.githubusercontent.com/952446/151608220-d12a1de1-255c-4744-afb6-4a37e53e93f0.png)

After:
![2022-01-28 at 20 18 08](https://user-images.githubusercontent.com/952446/151608075-6ca916ae-5fe2-439c-a56e-f1bd0bb881f1.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

yes
