### PR TITLE
feat: now deepmerge when copying data over from previous frontmatter

### DIFF
--- a/.changeset/proud-boats-appear.md
+++ b/.changeset/proud-boats-appear.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/utils": patch
+---
+
+feat: now deepmerge when copying data over from previous frontmatter

--- a/packages/eventcatalog-utils/package.json
+++ b/packages/eventcatalog-utils/package.json
@@ -18,6 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "deepmerge": "^4.2.2",
     "fs-extra": "^10.0.0",
     "gray-matter": "^4.0.3",
     "json2md": "^1.12.0",

--- a/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
+++ b/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
@@ -487,7 +487,7 @@ describe('eventcatalog-utils', () => {
               version: '1.0.0',
               summary: 'This is summary for my event',
               owners: ['dBoyne', 'anotherUser'],
-              producers: ['My First Producer']
+              producers: ['My First Producer'],
             };
 
             const { path: eventPath } = writeEventToCatalog(event, {
@@ -543,7 +543,6 @@ describe('eventcatalog-utils', () => {
 
             fs.rmdirSync(path.join(updatedEventPath), { recursive: true });
           });
-
         });
       });
     });

--- a/packages/eventcatalog-utils/src/events.ts
+++ b/packages/eventcatalog-utils/src/events.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import matter from 'gray-matter';
 import { Event } from '@eventcatalog/types';
+import merge from 'deepmerge';
 import buildMarkdownFile from './markdown-builder';
 
 import { FunctionInitInterface, WriteEventToCatalogOptions, WriteEventToCatalogResponse } from './types';
@@ -52,8 +53,8 @@ export const getAllEventsFromCatalog =
 
 export const buildEventMarkdownForCatalog =
   () =>
-  (event: Event, { markdownContent, includeSchemaComponent, defaultFrontMatter }: any = {}) => {
-    const frontMatter = { ...event, ...defaultFrontMatter };
+  (event: Event, { markdownContent, includeSchemaComponent, defaultFrontMatter = {} }: any = {}) => {
+    const frontMatter = merge(event, defaultFrontMatter);
     return buildMarkdownFile({ frontMatterObject: frontMatter, customContent: markdownContent, includeSchemaComponent });
   };
 


### PR DESCRIPTION
## Motivation

When using `utils` you could specify the frontmatter you want to carry over to new events, this is now merged with data from the new event rather than overriding it every time.
