### PR TITLE
feat: now supports multiple asyncapi files

### DIFF
--- a/.changeset/cyan-shirts-scream.md
+++ b/.changeset/cyan-shirts-scream.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/plugin-doc-generator-asyncapi": patch
+---
+
+feat: now supports multiple asyncapi files

--- a/.changeset/dry-cycles-visit.md
+++ b/.changeset/dry-cycles-visit.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/plugin-doc-generator-asyncapi": patch
+---
+
+feat: now supports multiple asyncapi files

--- a/.changeset/dry-cycles-visit.md
+++ b/.changeset/dry-cycles-visit.md
@@ -1,5 +1,0 @@
----
-"@eventcatalog/plugin-doc-generator-asyncapi": patch
----
-
-feat: now supports multiple asyncapi files

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/assets/valid-asyncapi-2.yml
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/assets/valid-asyncapi-2.yml
@@ -1,0 +1,23 @@
+asyncapi: '2.2.0'
+info:
+  title: Users Service
+  version: 1.0.0
+  description: This service is in charge of users
+channels:
+  user/signedup:
+    subscribe:
+      message:
+        $ref: '#/components/messages/UserSignedUp'
+components:
+  messages:
+    UserSignedUp:
+      payload:
+        type: object
+        properties:
+          displayName:
+            type: string
+            description: Name of the user
+          email:
+            type: string
+            format: email
+            description: Email of the user

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
@@ -1,5 +1,5 @@
 export type AsyncAPIPluginOptions = {
-  pathToSpec: string;
+  pathToSpec: string | string[];
   versionEvents?: boolean;
   externalAsyncAPIUrl?: string;
 };

--- a/website/docs/api/plugins/plugin-doc-generator-asyncapi.md
+++ b/website/docs/api/plugins/plugin-doc-generator-asyncapi.md
@@ -43,7 +43,7 @@ npm install --save @eventcatalog/plugin-doc-generator-asyncapi
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `pathToSpec` | `string` | `'/asyncapi.yml'` | Path to AsyncAPI document. |
+| `pathToSpec` | `string` or `string[]` | `'/asyncapi.yml'` | Path or Paths to AsyncAPI documents. |
 | `versionEvents` | `boolean` | `true` | When the plugin runs and it finds matching events in the catalog, it will version the events before creating the new documentation. |
 | `externalAsyncAPIUrl` | `string` | `` | When a AsyncAPI base url is set the, a external link to the AsyncAPI message documentation will be added to each event. |
 
@@ -64,8 +64,8 @@ module.exports = {
     [
       '@eventcatalog/plugin-doc-generator-asyncapi',
       {
-        // path to your AsyncAPI file
-        pathToSpec: path.join(__dirname, 'asyncapi.yml'),
+        // path to your AsyncAPI files
+        pathToSpec: [path.join(__dirname, 'asyncapi.yml')],
 
         // version events if already in catalog (optional)
         versionEvents: true


### PR DESCRIPTION

## Motivation

This small change allows people to specify multiple AsyncAPI files when using the generator.

Implementation for #146 

### Changes

• `pathToSpec` now accepts string or array.
• When events have been created the producers and consumers are now **merged** which allows the events to grow over multiple files.
