### PR TITLE
fix: mermaid service publish - subscribe

### DIFF
--- a/.changeset/popular-apes-heal.md
+++ b/.changeset/popular-apes-heal.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: mermaid diagram with pub/sub of same service now shows correctly

--- a/packages/eventcatalog/lib/__tests__/graphs.spec.ts
+++ b/packages/eventcatalog/lib/__tests__/graphs.spec.ts
@@ -25,7 +25,7 @@ describe('graphs', () => {
 
       expect(result.trim()).toEqual(`flowchart LR
 
-My_Event_2[My Event 2]:::producer-->My_Service[My Service]:::event
+l-My_Event_2[My Event 2]:::producer-->My_Service[My Service]:::event
 
 classDef event stroke:#2563eb,stroke-width: 4px;
 
@@ -33,7 +33,7 @@ classDef producer stroke:#75d7b6,stroke-width: 2px;
 
 classDef consumer stroke:#818cf8,stroke-width: 2px;
 
-My_Service[My Service]:::event-->My_Event[My Event]:::consumer
+My_Service[My Service]:::event-->r-My_Event[My Event]:::consumer
 
 click My_Event_2 href "/docs/events/My Event 2" "Go to My Event 2" _self
 
@@ -56,7 +56,7 @@ click My_Service href "/docs/services/My Service" "Go to My Service" _self`);
 
       expect(result.trim()).toEqual(`flowchart LR
 
-Service_1[Service 1]:::producer-->My_Event[My Event]:::event
+l-Service_1[Service 1]:::producer-->My_Event[My Event]:::event
 
 classDef event stroke:#2563eb,stroke-width: 4px;
 
@@ -64,7 +64,7 @@ classDef producer stroke:#75d7b6,stroke-width: 2px;
 
 classDef consumer stroke:#818cf8,stroke-width: 2px;
 
-My_Event[My Event]:::event-->Service_2[Service 2]:::consumer
+My_Event[My Event]:::event-->r-Service_2[Service 2]:::consumer
 
 click Service_1 href "/docs/services/Service 1" "Go to Service 1" _self
 

--- a/packages/eventcatalog/lib/__tests__/graphs.spec.ts
+++ b/packages/eventcatalog/lib/__tests__/graphs.spec.ts
@@ -35,9 +35,9 @@ classDef consumer stroke:#818cf8,stroke-width: 2px;
 
 My_Service[My Service]:::event-->r-My_Event[My Event]:::consumer
 
-click My_Event_2 href "/docs/events/My Event 2" "Go to My Event 2" _self
+click l-My_Event_2 href "/docs/events/My Event 2" "Go to My Event 2" _self
 
-click My_Event href "/docs/events/My Event" "Go to My Event" _self
+click r-My_Event href "/docs/events/My Event" "Go to My Event" _self
 
 click My_Service href "/docs/services/My Service" "Go to My Service" _self`);
     });
@@ -66,9 +66,9 @@ classDef consumer stroke:#818cf8,stroke-width: 2px;
 
 My_Event[My Event]:::event-->r-Service_2[Service 2]:::consumer
 
-click Service_1 href "/docs/services/Service 1" "Go to Service 1" _self
+click l-Service_1 href "/docs/services/Service 1" "Go to Service 1" _self
 
-click Service_2 href "/docs/services/Service 2" "Go to Service 2" _self
+click r-Service_2 href "/docs/services/Service 2" "Go to Service 2" _self
 
 click My_Event href "/docs/events/My Event" "Go to My Event" _self`);
     });

--- a/packages/eventcatalog/lib/graphs.ts
+++ b/packages/eventcatalog/lib/graphs.ts
@@ -20,8 +20,8 @@ classDef event stroke:${rootNodeColor},stroke-width: 4px;\n
 classDef producer stroke:#75d7b6,stroke-width: 2px;\n
 classDef consumer stroke:#818cf8,stroke-width: 2px;\n
 ${rightNodes.map((node) => `${centerNode.id}[${centerNode.name}]:::event-->r-${node.id}[${node.name}]:::consumer\n`).join('')}
-${leftNodes.map((node) => `click ${node.id} href "${node.link}" "Go to ${node.name}" _self\n`).join('')}
-${rightNodes.map((node) => `click ${node.id} href "${node.link}" "Go to ${node.name}" _self\n`).join('')}
+${leftNodes.map((node) => `click l-${node.id} href "${node.link}" "Go to ${node.name}" _self\n`).join('')}
+${rightNodes.map((node) => `click r-${node.id} href "${node.link}" "Go to ${node.name}" _self\n`).join('')}
 click ${centerNode.id} href "${centerNode.link}" "Go to ${centerNode.name}" _self\n
 `;
 

--- a/packages/eventcatalog/lib/graphs.ts
+++ b/packages/eventcatalog/lib/graphs.ts
@@ -15,11 +15,11 @@ const generateLink = (value, type) => (basePath !== '' ? `${basePath}/${type}/${
  * @param rootNodeColor
  */
 const buildMermaid = (centerNode, leftNodes, rightNodes, rootNodeColor) => `flowchart LR\n
-${leftNodes.map((node) => `${node.id}[${node.name}]:::producer-->${centerNode.id}[${centerNode.name}]:::event\n`).join('')}
+${leftNodes.map((node) => `l-${node.id}[${node.name}]:::producer-->${centerNode.id}[${centerNode.name}]:::event\n`).join('')}
 classDef event stroke:${rootNodeColor},stroke-width: 4px;\n
 classDef producer stroke:#75d7b6,stroke-width: 2px;\n
 classDef consumer stroke:#818cf8,stroke-width: 2px;\n
-${rightNodes.map((node) => `${centerNode.id}[${centerNode.name}]:::event-->${node.id}[${node.name}]:::consumer\n`).join('')}
+${rightNodes.map((node) => `${centerNode.id}[${centerNode.name}]:::event-->r-${node.id}[${node.name}]:::consumer\n`).join('')}
 ${leftNodes.map((node) => `click ${node.id} href "${node.link}" "Go to ${node.name}" _self\n`).join('')}
 ${rightNodes.map((node) => `click ${node.id} href "${node.link}" "Go to ${node.name}" _self\n`).join('')}
 click ${centerNode.id} href "${centerNode.link}" "Go to ${centerNode.name}" _self\n


### PR DESCRIPTION
## Motivation

When the same events/services are being used in different directions in a diagram, Mermaid considers them the same and renders them as 1 node. This results in graphs like in the screenshot. Not sure if this is desired behaviour?

The PR solves it by making the nodes unique per direction, by adding a little prefix in front of the ID.

Before PR:
![2022-02-04 at 23 44 45](https://user-images.githubusercontent.com/952446/152613927-4398bddf-b82b-44ff-b3d4-b77ace2aac8f.png)
![2022-02-04 at 23 56 57](https://user-images.githubusercontent.com/952446/152614155-73951326-19ed-4a69-9fd3-ff4b61b349b8.png)

After PR: 
![2022-02-04 at 23 53 09](https://user-images.githubusercontent.com/952446/152613909-9149ec69-8b59-44d8-ac0d-6b1badd77b1c.png)
![2022-02-04 at 23 57 29](https://user-images.githubusercontent.com/952446/152614179-1dccf7d1-2865-4e4d-95fa-c0a7739fbc44.png)



### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)
