### PR TITLE
chore: update all examples to render node graphs vs mermaid

### DIFF
--- a/.changeset/two-fans-melt.md
+++ b/.changeset/two-fans-melt.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+chore: update all examples to render node graphs vs mermaid

--- a/examples/basic/events/AddedItemToCart/index.md
+++ b/examples/basic/events/AddedItemToCart/index.md
@@ -26,8 +26,10 @@ This event can be triggered multiple times per customer. Everytime the customer 
 
 We have a frontend application that allows users to buy things from our store. This front end interacts directly with the `Basket Service` to add items to the cart. The `Basket Service` will raise the events.
 
-<Mermaid title="Consumer / Producer Diagram" />
+<NodeGraph />
 
-<EventExamples title="How to trigger event" />
+<EventExamples title="Examples of how to trigger event" />
 
 <Schema />
+
+<SchemaViewer renderRootTreeLines defaultExpandedDepth='0' maxHeight="500" />

--- a/examples/basic/events/OrderComplete/index.md
+++ b/examples/basic/events/OrderComplete/index.md
@@ -18,8 +18,6 @@ owners:
 
 This event is the final event of the ordering process. It gets raised when the shipment has been delivered.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer/Producer Diagram" />
 
 <Schema />

--- a/examples/basic/events/OrderConfirmed/index.md
+++ b/examples/basic/events/OrderConfirmed/index.md
@@ -18,8 +18,6 @@ owners:
 
 This event is triggered when the customers order has been verified and the stock has been checked. Once this event is triggered we are safe to say it is ready for shipment.
 
-### Consumer / Producer Diagram
-
-<NodeGraph />
+<NodeGraph title="Consumer/Producer Diagram" />
 
 <Schema />

--- a/examples/basic/events/OrderRequested/index.md
+++ b/examples/basic/events/OrderRequested/index.md
@@ -20,8 +20,6 @@ This event is triggered when the user confirms their order and wants to process 
 
 We have a frontend application that allows users to buy things from our store. The frontend application interacts with the Backet Service to trigger the `OrderRequested` event.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer/Producer Diagram" />
 
 <Schema />

--- a/examples/basic/events/PaymentProcessed/index.md
+++ b/examples/basic/events/PaymentProcessed/index.md
@@ -20,8 +20,6 @@ This event is triggered when the payment has succesfully been processed for a cu
 
 We use Stripe to handle customer payments. The Payment Service listens for Stripe webhooks and raises the PaymentProcessed event.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer/Producer Diagram" />
 
 <Schema />

--- a/examples/basic/events/RemovedItemFromCart/index.md
+++ b/examples/basic/events/RemovedItemFromCart/index.md
@@ -23,8 +23,6 @@ This event can be triggered multiple times per customer. Everytime the customer 
 We have a frontend application that allows users to buy things from our store. This front end interacts directly with the `Basket Service` to add items to the cart. The `Basket Service` will raise the events.
 
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer/Producer Diagram" />
 
 <Schema />

--- a/examples/basic/events/ShipmentDelivered/index.md
+++ b/examples/basic/events/ShipmentDelivered/index.md
@@ -19,7 +19,6 @@ owners:
 
 This event is triggered when a shipment has been delivered to its destination.
 
-### Consumer / Producer Diagram
-<NodeGraph isAnimated={true} />
+<NodeGraph title="Consumer/Producer Diagram" />
 
 <Schema />

--- a/examples/basic/events/ShipmentDispatched/index.md
+++ b/examples/basic/events/ShipmentDispatched/index.md
@@ -18,8 +18,6 @@ owners:
 
 This event is triggered when a shipment has been dispatched from the warehouse.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer/Producer Diagram" />
 
 <Schema />

--- a/examples/basic/events/ShipmentPrepared/index.md
+++ b/examples/basic/events/ShipmentPrepared/index.md
@@ -18,8 +18,6 @@ owners:
 
 This event is triggered when a shipment has finished being prepared. 
 
-### Consumer / Producer Diagram
-
-<NodeGraph />
+<NodeGraph title="Consumer/Producer Diagram" />
 
 <SchemaViewer renderRootTreeLines defaultExpandedDepth='0' maxHeight="500" />

--- a/examples/basic/services/Basket Service/index.md
+++ b/examples/basic/services/Basket Service/index.md
@@ -16,4 +16,4 @@ Simple API that handles interactions between users and their baskets. Use this s
 
 This service will also generate Async events for downstream services.
 
-<Mermaid />
+<NodeGraph />

--- a/examples/basic/services/Data Lake/index.md
+++ b/examples/basic/services/Data Lake/index.md
@@ -8,4 +8,4 @@ owners:
 
 Our internal Data Lake platform used by the data team to consume events of our Architecture and provide valuable insights and analytics.
 
-<Mermaid />
+<NodeGraph />

--- a/examples/basic/services/Payment Service/index.md
+++ b/examples/basic/services/Payment Service/index.md
@@ -10,4 +10,4 @@ The payment service is our own internal payment service that listens to events f
 
 We use Stripe to handle services and use this Payment service to enrich events for internal use.
 
-<Mermaid />
+<NodeGraph />

--- a/packages/create-eventcatalog/templates/default/events/AddedItemToCart/index.md
+++ b/packages/create-eventcatalog/templates/default/events/AddedItemToCart/index.md
@@ -22,11 +22,10 @@ This event can be triggered multiple times per customer. Everytime the customer 
 
 We have a frontend application that allows users to buy things from our store. This front end interacts directly with the `Basket Service` to add items to the cart. The `Basket Service` will raise the events.
 
-
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer / Producer Diagram" />
 
 <EventExamples title="How to trigger event" />
 
 <Schema />
+
+<SchemaViewer renderRootTreeLines defaultExpandedDepth='0' maxHeight="500" />

--- a/packages/create-eventcatalog/templates/default/events/OrderComplete/index.md
+++ b/packages/create-eventcatalog/templates/default/events/OrderComplete/index.md
@@ -18,8 +18,6 @@ owners:
 
 This event is the final event of the ordering process. It gets raised when the shipment has been delivered.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer / Producer Diagram" />
 
 <Schema />

--- a/packages/create-eventcatalog/templates/default/events/OrderConfirmed/index.md
+++ b/packages/create-eventcatalog/templates/default/events/OrderConfirmed/index.md
@@ -18,8 +18,6 @@ owners:
 
 This event is triggered when the customers order has been verified and the stock has been checked. Once this event is triggered we are safe to say it is ready for shipment.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer / Producer Diagram" />
 
 <Schema />

--- a/packages/create-eventcatalog/templates/default/events/OrderRequested/index.md
+++ b/packages/create-eventcatalog/templates/default/events/OrderRequested/index.md
@@ -20,8 +20,6 @@ This event is triggered when the user confirms their order and wants to process 
 
 We have a frontend application that allows users to buy things from our store. The frontend application interacts with the Backet Service to trigger the `OrderRequested` event.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer / Producer Diagram" />
 
 <Schema />

--- a/packages/create-eventcatalog/templates/default/events/PaymentProcessed/index.md
+++ b/packages/create-eventcatalog/templates/default/events/PaymentProcessed/index.md
@@ -20,8 +20,6 @@ This event is triggered when the payment has succesfully been processed for a cu
 
 We use Stripe to handle customer payments. The Payment Service listens for Stripe webhooks and raises the PaymentProcessed event.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer / Producer Diagram" />
 
 <Schema />

--- a/packages/create-eventcatalog/templates/default/events/RemovedItemFromCart/index.md
+++ b/packages/create-eventcatalog/templates/default/events/RemovedItemFromCart/index.md
@@ -23,8 +23,6 @@ This event can be triggered multiple times per customer. Everytime the customer 
 We have a frontend application that allows users to buy things from our store. This front end interacts directly with the `Basket Service` to add items to the cart. The `Basket Service` will raise the events.
 
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer / Producer Diagram" />
 
 <Schema />

--- a/packages/create-eventcatalog/templates/default/events/ShipmentDelivered/index.md
+++ b/packages/create-eventcatalog/templates/default/events/ShipmentDelivered/index.md
@@ -19,8 +19,6 @@ owners:
 
 This event is triggered when a shipment has been delievered to it's destination.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer / Producer Diagram" />
 
 <Schema />

--- a/packages/create-eventcatalog/templates/default/events/ShipmentDispatched/index.md
+++ b/packages/create-eventcatalog/templates/default/events/ShipmentDispatched/index.md
@@ -18,8 +18,6 @@ owners:
 
 This event is triggered when a shipment has been dispatched from the warehouse.
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer / Producer Diagram" />
 
 <Schema />

--- a/packages/create-eventcatalog/templates/default/events/ShipmentPrepared/index.md
+++ b/packages/create-eventcatalog/templates/default/events/ShipmentPrepared/index.md
@@ -18,8 +18,6 @@ owners:
 
 This event is triggered when a shipment has finished being prepared. 
 
-### Consumer / Producer Diagram
-
-<Mermaid />
+<NodeGraph title="Consumer / Producer Diagram" />
 
 <Schema />

--- a/packages/create-eventcatalog/templates/default/services/Basket Service/index.md
+++ b/packages/create-eventcatalog/templates/default/services/Basket Service/index.md
@@ -13,4 +13,4 @@ Simple API that handles interactions between users and their baskets. Use this s
 
 This service will also generate Async events for downstream services.
 
-<Mermaid />
+<NodeGraph />

--- a/packages/create-eventcatalog/templates/default/services/Data Lake/index.md
+++ b/packages/create-eventcatalog/templates/default/services/Data Lake/index.md
@@ -8,4 +8,4 @@ owners:
 
 Our internal Data Lake platform used by the data team to consume events of our Architecture and provide valuable insights and analytics.
 
-<Mermaid />
+<NodeGraph />

--- a/packages/create-eventcatalog/templates/default/services/Payment Service/index.md
+++ b/packages/create-eventcatalog/templates/default/services/Payment Service/index.md
@@ -10,4 +10,4 @@ The payment service is our own internal payment service that listens to events f
 
 We use Stripe to handle services and use this Payment service to enrich events for internal use.
 
-<Mermaid />
+<NodeGraph />

--- a/packages/create-eventcatalog/templates/default/services/Shipping Service/index.md
+++ b/packages/create-eventcatalog/templates/default/services/Shipping Service/index.md
@@ -13,4 +13,4 @@ Event based service that allows you to create shipments, prepare them and dispat
 
 This service will also generate Async events for downstream services.
 
-<Mermaid />
+<NodeGraph />


### PR DESCRIPTION
## Motivation

With the new release of the new `<NodeGraph/>` this PR will move all our examples to use `NodeGraph` vs `Mermaid`.

Mermaid is still there for use, but moving over to NodeGraph as I believe it's a better UX.
