### PR TITLE
fix: increase node width for NodeGraph

### DIFF
--- a/.changeset/khaki-colts-appear.md
+++ b/.changeset/khaki-colts-appear.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: increase node width for NodeGraph

--- a/packages/eventcatalog/components/Mdx/NodeGraph/GraphElements.ts
+++ b/packages/eventcatalog/components/Mdx/NodeGraph/GraphElements.ts
@@ -6,7 +6,7 @@ const { publicRuntimeConfig: { basePath = '' } = {} } = getConfig();
 
 const MIN_NODE_WIDTH = 150;
 const generateLink = (value, type) => (basePath !== '' ? `${basePath}/${type}/${value}` : `/${type}/${value}`);
-const calcWidth = (value) => (value.length * 7 > MIN_NODE_WIDTH ? value.length * 7 : MIN_NODE_WIDTH);
+const calcWidth = (value) => (value.length * 8 > MIN_NODE_WIDTH ? value.length * 8 : MIN_NODE_WIDTH);
 
 const buildNodeEdge = ({ id, target, source, isAnimated = true }) => ({
   id,

--- a/packages/eventcatalog/components/Mdx/NodeGraph/__tests__/__snapshots__/GraphElements.spec.ts.snap
+++ b/packages/eventcatalog/components/Mdx/NodeGraph/__tests__/__snapshots__/GraphElements.spec.ts.snap
@@ -6,7 +6,7 @@ Array [
     "data": Object {
       "label": "Service 1",
       "link": "/docs/services/Service 1",
-      "maxWidth": -253,
+      "maxWidth": -332,
       "width": 150,
     },
     "id": "pr-Service_1",
@@ -24,7 +24,7 @@ Array [
     "data": Object {
       "label": "Service 2",
       "link": "/docs/services/Service 2",
-      "maxWidth": -253,
+      "maxWidth": -332,
       "width": 150,
     },
     "id": "pr-Service_2",
@@ -42,8 +42,8 @@ Array [
     "data": Object {
       "label": "very very very very very very very very very very very very long name Service 3",
       "link": "/docs/services/very very very very very very very very very very very very long name Service 3",
-      "maxWidth": 553,
-      "width": 553,
+      "maxWidth": 632,
+      "width": 632,
     },
     "id": "pr-very_very_very_very_very_very_very_very_very_very_very_very_long_name_Service_3",
     "position": Object {
@@ -52,7 +52,7 @@ Array [
     },
     "style": Object {
       "border": "2px solid #75d7b6",
-      "width": 553,
+      "width": 632,
     },
     "type": "input",
   },
@@ -77,7 +77,7 @@ Array [
     "data": Object {
       "label": "Service 4",
       "link": "/docs/services/Service 4",
-      "maxWidth": 539,
+      "maxWidth": 616,
       "width": 150,
     },
     "id": "co-Service_4",
@@ -95,7 +95,7 @@ Array [
     "data": Object {
       "label": "Service 5",
       "link": "/docs/services/Service 5",
-      "maxWidth": 539,
+      "maxWidth": 616,
       "width": 150,
     },
     "id": "co-Service_5",
@@ -113,7 +113,7 @@ Array [
     "data": Object {
       "label": "Service 6",
       "link": "/docs/services/Service 6",
-      "maxWidth": 539,
+      "maxWidth": 616,
       "width": 150,
     },
     "id": "co-Service_6",
@@ -131,7 +131,7 @@ Array [
     "data": Object {
       "label": "Service 7",
       "link": "/docs/services/Service 7",
-      "maxWidth": 539,
+      "maxWidth": 616,
       "width": 150,
     },
     "id": "co-Service_7",
@@ -149,7 +149,7 @@ Array [
     "data": Object {
       "label": "Service 8",
       "link": "/docs/services/Service 8",
-      "maxWidth": 539,
+      "maxWidth": 616,
       "width": 150,
     },
     "id": "co-Service_8",
@@ -167,8 +167,8 @@ Array [
     "data": Object {
       "label": "very.very.very.very.very.very.very.very.very.very.very.very.long.name.event.8",
       "link": "/docs/services/very.very.very.very.very.very.very.very.very.very.very.very.long.name.event.8",
-      "maxWidth": 539,
-      "width": 539,
+      "maxWidth": 616,
+      "width": 616,
     },
     "id": "co-very.very.very.very.very.very.very.very.very.very.very.very.long.name.event.8",
     "position": Object {
@@ -177,7 +177,7 @@ Array [
     },
     "style": Object {
       "border": "2px solid #818cf8",
-      "width": 539,
+      "width": 616,
     },
     "type": "output",
   },
@@ -336,8 +336,8 @@ Array [
     "data": Object {
       "label": "very very very very very very very very very very very very long name event 5",
       "link": "/docs/events/very very very very very very very very very very very very long name event 5",
-      "maxWidth": 539,
-      "width": 539,
+      "maxWidth": 616,
+      "width": 616,
     },
     "id": "sub-very_very_very_very_very_very_very_very_very_very_very_very_long_name_event_5",
     "position": Object {
@@ -346,7 +346,7 @@ Array [
     },
     "style": Object {
       "border": "2px solid #75d7b6",
-      "width": 539,
+      "width": 616,
     },
     "type": "input",
   },
@@ -354,7 +354,7 @@ Array [
     "data": Object {
       "label": "My Event 6",
       "link": "/docs/events/My Event 6",
-      "maxWidth": -239,
+      "maxWidth": -316,
       "width": 150,
     },
     "id": "sub-My_Event_6",
@@ -372,7 +372,7 @@ Array [
     "data": Object {
       "label": "My Event 7",
       "link": "/docs/events/My Event 7",
-      "maxWidth": -239,
+      "maxWidth": -316,
       "width": 150,
     },
     "id": "sub-My_Event_7",
@@ -390,7 +390,7 @@ Array [
     "data": Object {
       "label": "My Event 8",
       "link": "/docs/events/My Event 8",
-      "maxWidth": -239,
+      "maxWidth": -316,
       "width": 150,
     },
     "id": "sub-My_Event_8",
@@ -408,7 +408,7 @@ Array [
     "data": Object {
       "label": "My Event 9",
       "link": "/docs/events/My Event 9",
-      "maxWidth": -239,
+      "maxWidth": -316,
       "width": 150,
     },
     "id": "sub-My_Event_9",
@@ -443,7 +443,7 @@ Array [
     "data": Object {
       "label": "My Event",
       "link": "/docs/events/My Event",
-      "maxWidth": 539,
+      "maxWidth": 616,
       "width": 150,
     },
     "id": "pub-My_Event",
@@ -461,7 +461,7 @@ Array [
     "data": Object {
       "label": "My Event 2",
       "link": "/docs/events/My Event 2",
-      "maxWidth": 539,
+      "maxWidth": 616,
       "width": 150,
     },
     "id": "pub-My_Event_2",
@@ -479,7 +479,7 @@ Array [
     "data": Object {
       "label": "My Event 3",
       "link": "/docs/events/My Event 3",
-      "maxWidth": 539,
+      "maxWidth": 616,
       "width": 150,
     },
     "id": "pub-My_Event_3",
@@ -497,8 +497,8 @@ Array [
     "data": Object {
       "label": "very.very.very.very.very.very.very.very.very.very.very.very.long.name.event.4",
       "link": "/docs/events/very.very.very.very.very.very.very.very.very.very.very.very.long.name.event.4",
-      "maxWidth": 539,
-      "width": 539,
+      "maxWidth": 616,
+      "width": 616,
     },
     "id": "pub-very.very.very.very.very.very.very.very.very.very.very.very.long.name.event.4",
     "position": Object {
@@ -507,7 +507,7 @@ Array [
     },
     "style": Object {
       "border": "2px solid #818cf8",
-      "width": 539,
+      "width": 616,
     },
     "type": "output",
   },


### PR DESCRIPTION
## Motivation

The NodeGraph minimum width logic resulted in a too small node.
This PR increased the node width for NodeGraph.

before:
<img width="1288" alt="2022-02-07 at 20 53 01@2x" src="https://user-images.githubusercontent.com/952446/152861504-1bebfe95-e57c-4155-86c2-b1548a6a0689.png">


after:
<img width="1285" alt="2022-02-07 at 20 51 59@2x" src="https://user-images.githubusercontent.com/952446/152861363-73880038-5b4b-4a8b-95d9-c272e5664352.png">

<img width="947" alt="2022-02-07 at 20 49 29@2x" src="https://user-images.githubusercontent.com/952446/152861201-138caaf1-30f8-4151-b6cf-e1ec7193041f.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?
Yes
