### PR TITLE
fix(logs): break line in diff view

### DIFF
--- a/.changeset/large-hairs-wonder.md
+++ b/.changeset/large-hairs-wonder.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix(logs): break line in diff view

--- a/packages/eventcatalog/styles/globals.css
+++ b/packages/eventcatalog/styles/globals.css
@@ -47,6 +47,20 @@ event-table thead th {
   user-select: none;
 }
 
-.react-flow__controls-no-shadow{
+.react-flow__controls-no-shadow {
   box-shadow: none !important;
+}
+
+.d2h-diff-table .d2h-code-side-line {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-template-columns: auto 1fr;
+  grid-gap: 0.6em;
+  margin-bottom: 0.05em;
+  padding-right: 4.2em;
+}
+
+.d2h-diff-table .d2h-code-line,
+.d2h-diff-table .d2h-code-line-ctn {
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixes https://github.com/boyney123/eventcatalog/issues/183.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

---


If you're wondering what this piece of code is about:

```css
.d2h-diff-table .d2h-code-side-line {
  display: inline-grid;
  grid-auto-flow: column;
  grid-template-columns: auto 1fr;
  grid-gap: 0.6em;
  margin-bottom: 0.05em;
  padding-right: 4.2em;
}
```

It keeps the position of the `+`/`-` prefix (see line 38 on the right side):
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/1152805/153551195-9268e13b-e7d3-4c6a-a2f6-b866b729f7c5.png">

Without it the prefix would be centered to the "line height" (which looks weird if there are a lot of line breaks) (see line 38 on the right side):
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/1152805/153551289-0116cff3-950d-44ab-9cc7-bc84e06d3e8a.png">

---

Other notes:
- Kudos for the project, the Contributing instructions and having a useful default example. Everything is very easy to follow! 👍
- The Contributing instructions mention a `main` branch, but the project actually uses `master`.