### PR TITLE
allow deep link to an event field

### DIFF
--- a/.changeset/late-tips-lay.md
+++ b/.changeset/late-tips-lay.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+allow deep linking event field

--- a/packages/eventcatalog/components/Mdx/SchemaViewer/SchemaViewer.tsx
+++ b/packages/eventcatalog/components/Mdx/SchemaViewer/SchemaViewer.tsx
@@ -1,11 +1,14 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
-import { JsonSchemaViewer } from '@stoplight/json-schema-viewer';
+import { JsonSchemaViewer, RowAddonRenderer } from '@stoplight/json-schema-viewer';
 import { injectStyles } from '@stoplight/mosaic';
+import { useRouter } from 'next/router';
 import styles from './SchemaViewer.module.css';
 
 // Inject Stoplight styles
 injectStyles();
+
+const targetBase = 'event-definition-';
 
 type Props = {
   schema: any;
@@ -18,17 +21,52 @@ type Props = {
 function SchemaViewer({ schema, maxHeight, renderRootTreeLines = false, hideExamples = false, defaultExpandedDepth = 1 }: Props) {
   const JsonSchema = useMemo(() => JSON.parse(schema as string), [schema]);
 
+  const [initialScrollTo, setInitialScrollTo] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    if (router.isReady && window.location.hash.startsWith(`#${targetBase}`)) {
+      setInitialScrollTo(window.location.hash);
+    }
+  }, [router.isReady]);
+
+  useEffect(() => {
+    if (!initialScrollTo) return;
+    const element = document.querySelector(initialScrollTo);
+    element.scrollIntoView();
+  }, [initialScrollTo]);
+
   return (
     <JsonSchemaViewer
+      key={initialScrollTo}
       schema={JsonSchema}
       emptyText="No schema defined"
       maxHeight={maxHeight}
-      defaultExpandedDepth={defaultExpandedDepth}
+      defaultExpandedDepth={initialScrollTo ? Infinity : defaultExpandedDepth}
+      renderRowAddon={renderRowAddon}
       renderRootTreeLines={renderRootTreeLines}
       hideExamples={hideExamples}
       className={styles.schemaViewer}
     />
   );
 }
+
+const renderRowAddon: RowAddonRenderer = ({ schemaNode }) => {
+  const segments: string[] = [];
+  let node = schemaNode;
+  while (node) {
+    const segment = node.subpath.slice(-1)[0];
+    if (!segment) break;
+    segments.unshift(segment);
+    node = node.parent;
+  }
+  const id = `${targetBase}${segments.join('-')}`;
+
+  return (
+    <a id={id} href={`#${id}`} aria-hidden="true" className="ml-2">
+      #
+    </a>
+  );
+};
 
 export default SchemaViewer;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

In order to share documentation for single fields in long event definitions efficiently it would be nice, if we could use individual fields as a target.

Ideally this feature would be build into `@stoplight/json-schema-viewer`, but thanks to `renderRowAddon` it can also be implemented in user land.

Sadly because we collapse event definitions by default it is not super easy to target them. We actually have to wait for the client side rendering to become available to check, if an anchor was used. Due to some rendering bug we then have to re-render `<JsonSchemaViewer/>` by changing the `key` (this of course only happens if you make use of this feature - no negative impact for other users). After that we can manually scroll to the field.

<img width="969" alt="image" src="https://user-images.githubusercontent.com/1152805/155999666-830309a8-4335-490c-9a43-949656c47a3a.png">

(Added the small `#` icon at the end.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
