### PR TITLE
fix: now check for events dir before moving schemas

### DIFF
--- a/.changeset/chatty-laws-attack.md
+++ b/.changeset/chatty-laws-attack.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: now check for events dir before moving schemas

--- a/packages/eventcatalog/scripts/move-schemas-for-download.js
+++ b/packages/eventcatalog/scripts/move-schemas-for-download.js
@@ -69,8 +69,10 @@ const main = async () => {
     });
   }
 
-  // just parse the events directory (without domains)
-  parseEventDirectory(publicSchemaDir, eventsWithoutDomainsDir);
+  if (fs.existsSync(eventsWithoutDomainsDir)) {
+    // just parse the events directory (without domains)
+    parseEventDirectory(publicSchemaDir, eventsWithoutDomainsDir);
+  }
 };
 
 main();


### PR DESCRIPTION
## Motivation

If user removes `events` directory from the catalog they will get an error when the `move-schemas-for-download.js` is run, failing to find the events directory. 

This fix now checks the directory before trying to do anything to it, as the `events` directory is now optional
