### PR TITLE
add a stable render key for events

### DIFF
--- a/.changeset/itchy-humans-tickle.md
+++ b/.changeset/itchy-humans-tickle.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+add a stable render key for events

--- a/packages/eventcatalog/components/Grids/EventGrid.tsx
+++ b/packages/eventcatalog/components/Grids/EventGrid.tsx
@@ -23,9 +23,10 @@ function EventGrid({ events = [], showMermaidDiagrams = false }: EventGridProps)
       {events.map((event) => {
         const { draft: isDraft, domain } = event;
         const eventURL = domain ? `/domains/${domain}/events/${event.name}` : `/events/${event.name}`;
+        const eventKey = domain ? `${domain}-${event.name}` : event.name;
 
         return (
-          <li key={event.name} className="flex">
+          <li key={eventKey} className="flex">
             <Link href={eventURL}>
               <a className="flex shadow-sm rounded-md w-full">
                 <div


### PR DESCRIPTION
## Motivation

This will fix issues if you have events with the same name but different domain. Without this change you would get weird results in the overview page of events being rendered with filters active that should hide them.

### Have you read the [Contributing Guidelines on pull requests

Yes
