### PR TITLE
feat:  Analytics - Added  Google Analytics option

### DIFF
--- a/examples/basic/eventcatalog.config.js
+++ b/examples/basic/eventcatalog.config.js
@@ -8,6 +8,9 @@ module.exports = {
     alt: 'EventCatalog Logo',
     src: 'logo.svg',
   },
+  analytics: {
+    googleAnalyticsTrackingId: 'G-Y0XQQQQQQQ',
+  },
   footerLinks: [
     { label: 'Events', href: '/events' },
     { label: 'Services', href: '/services' },

--- a/packages/eventcatalog-types/src/index.d.ts
+++ b/packages/eventcatalog-types/src/index.d.ts
@@ -84,7 +84,11 @@ export interface OpenGraphConfig {
   ogImage?: string;
 }
 
-export interface EventCataLogConfig {
+export interface AnalyticsConfig {
+  googleAnalyticsTrackingId?: string;
+}
+
+export interface EventCatalogConfig {
   title: string;
   tagline?: string;
   editUrl?: string;
@@ -95,8 +99,9 @@ export interface EventCataLogConfig {
   footerLinks?: Link[];
   homepageLink?: string;
   openGraph?: OpenGraphConfig;
+  analytics?: AnalyticsConfig;
 }
 
 export type LoadContext = {
-  eventCatalogConfig: EventCataLogConfig;
+  eventCatalogConfig: EventCatalogConfig;
 };

--- a/packages/eventcatalog/hooks/EventCatalog.tsx
+++ b/packages/eventcatalog/hooks/EventCatalog.tsx
@@ -1,15 +1,15 @@
 import React, { useContext, ReactNode } from 'react';
-import type { EventCataLogConfig, User } from '@eventcatalog/types';
+import type { EventCatalogConfig, User } from '@eventcatalog/types';
 import path from 'path';
 import defaultConfig from '../eventcatalog.config';
 
-export const Context = React.createContext<EventCataLogConfig | null>(defaultConfig);
+export const Context = React.createContext<EventCatalogConfig | null>(defaultConfig);
 
 export function EventCatalogContextProvider({ children }: { children: ReactNode }): JSX.Element {
   return <Context.Provider value={defaultConfig}>{children}</Context.Provider>;
 }
 
-export const useConfig = () => useContext<EventCataLogConfig>(Context);
+export const useConfig = () => useContext<EventCatalogConfig>(Context);
 
 export const useUser = () => {
   const config = useConfig();

--- a/packages/eventcatalog/lib/analytics.ts
+++ b/packages/eventcatalog/lib/analytics.ts
@@ -1,0 +1,27 @@
+import { AnalyticsConfig } from "@eventcatalog/types";
+
+import config from 'eventcatalog.config';
+
+const {analytics} = config
+const { googleAnalyticsTrackingId } = analytics as AnalyticsConfig;
+
+/**
+ * Register page view event
+ * @param url
+ */
+export const pageview = (url) => {
+  if (window?.gtag && googleAnalyticsTrackingId) {
+    window.gtag('config', googleAnalyticsTrackingId, {
+      page_path: url
+    });
+  }
+};
+
+/**
+ * Register event
+ * @param action
+ * @param category
+ */
+export const event = ({ action, params }) => {
+  window.gtag("event", action, params);
+};

--- a/packages/eventcatalog/pages/_app.tsx
+++ b/packages/eventcatalog/pages/_app.tsx
@@ -3,25 +3,46 @@ import { AppProps } from 'next/app';
 
 import Head from 'next/head';
 import getConfig from 'next/config';
-import { OpenGraphConfig } from '@eventcatalog/types';
+import { AnalyticsConfig, OpenGraphConfig } from "@eventcatalog/types";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import Script from "next/script";
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import { EventCatalogContextProvider, useConfig } from '@/hooks/EventCatalog';
+import * as ga from '../lib/analytics'
 
 function Page({ Component, pageProps }: AppProps) {
   const {
     title = 'EventCatalog | Discover, Explore and Document your Event Driven Architectures.',
     tagline = 'An open source tool powered by markdown to document your Event Driven Architecture.',
     homepageLink = 'https://eventcatalog.dev/',
+    analytics,
     openGraph = {},
   } = useConfig();
   const { publicRuntimeConfig: { basePath = '' } = {} } = getConfig();
+  const { googleAnalyticsTrackingId } = analytics as AnalyticsConfig;
   const {
     ogTitle = title,
     ogDescription = tagline,
     ogImage = 'https://eventcatalog.dev/img/opengraph.png',
     ogUrl = homepageLink,
   } = openGraph as OpenGraphConfig;
+
+  const router = useRouter()
+  useEffect(() => {
+    const handleRouteChange = (url) => {
+      console.log('googleAnalyticsTrackingId', googleAnalyticsTrackingId)
+      if (googleAnalyticsTrackingId) {
+        // Track page views
+        ga.pageview(url);
+      }
+    }
+    router.events.on('routeChangeComplete', handleRouteChange)
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [router.events])
 
   return (
     <EventCatalogContextProvider>
@@ -46,6 +67,27 @@ function Page({ Component, pageProps }: AppProps) {
         )}
         <meta property="og:locale" content="en-GB" />
         <meta name="author" content="David Boyne" />
+
+        {googleAnalyticsTrackingId && (
+          <>
+            {/* Global Site Tag (gtag.js) - Google Analytics */}
+            <Script
+              strategy="afterInteractive"
+              src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsTrackingId}`} />
+            <Script
+              strategy="afterInteractive"
+              dangerouslySetInnerHTML={{
+                __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${googleAnalyticsTrackingId}', {
+                page_path: window.location.pathname,
+              });`,
+              }}
+            />
+          </>
+        )}
       </Head>
       <Header />
       <Component {...pageProps} />

--- a/website/docs/api/eventcatalog.config.js.md
+++ b/website/docs/api/eventcatalog.config.js.md
@@ -138,6 +138,16 @@ module.exports = {
 };
 ```
 
+### `analytics` {#analytics}
+
+- Type: `googleAnalyticsTrackingId`: value for the Google Analytics tracking ID
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  analytics: { googleAnalyticsTrackingId: 'GA-XXXXX-X' }
+};
+```
+
 ### `basePath` {#basepath}
 
 Set the `basePath` in order to be able to deploy the eventcatalog under a sub-path of the domain.


### PR DESCRIPTION
## Motivation

Getting insights what visitors are doing in EventCatalog is a powerful to tool for any team.
Adding analytics to collect some anonymous visitor statistics will help the owners, understand which events / services are most visited.

This PR adds the basic collection using Google Analytics using the proposed setup by [NextJS](https://nextjs.org/docs/messages/next-script-for-ga).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
