### PR TITLE
improve typings

### DIFF
--- a/.changeset/olive-dingos-reflect.md
+++ b/.changeset/olive-dingos-reflect.md
@@ -1,0 +1,7 @@
+---
+"@eventcatalog/types": patch
+"@eventcatalog/utils": patch
+"@eventcatalog/core": patch
+---
+
+improve typings

--- a/.changeset/olive-dingos-reflect.md
+++ b/.changeset/olive-dingos-reflect.md
@@ -4,4 +4,4 @@
 "@eventcatalog/core": patch
 ---
 
-improve typings
+chore: improve typings

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "lerna": "^4.0.0",
     "lerna-changelog": "^2.2.0",
     "prettier": "^2.1.2",
-    "typescript": "^4.5.2"
+    "typescript": "^4.6.2"
   }
 }

--- a/packages/eventcatalog-types/src/index.d.ts
+++ b/packages/eventcatalog-types/src/index.d.ts
@@ -22,13 +22,13 @@ export interface Event {
   draft?: boolean;
   summary?: string;
   domain?: string | null;
-  producerNames?: string[] | Service[] | [];
-  consumerNames?: string[] | Service[] | [];
-  producers?: Service[] | [];
-  consumers?: Service[] | [];
+  producerNames?: string[] | Service[];
+  consumerNames?: string[] | Service[];
+  producers?: Service[];
+  consumers?: Service[];
 
   historicVersions?: string[];
-  owners?: Owner[] | string[] | [];
+  owners?: Owner[] | string[];
   examples?: any;
   schema?: any;
   externalLinks?: Tag[];
@@ -50,9 +50,9 @@ export interface Service {
   repository?: Repository;
   draft?: boolean;
   domain?: string;
-  publishes?: Event[] | [];
-  subscribes?: Event[] | [];
-  owners?: Owner[] | string[] | [];
+  publishes?: Event[];
+  subscribes?: Event[];
+  owners?: Owner[] | string[];
   tags?: Tag[];
   externalLinks?: Tag[];
   openAPISpec?: string;
@@ -61,9 +61,9 @@ export interface Service {
 export interface Domain {
   name: string;
   summary: string;
-  services?: Service[] | [];
-  events?: Event[] | [];
-  owners?: Owner[] | string[] | [];
+  services?: Service[];
+  events?: Event[];
+  owners?: Owner[] | string[];
   tags?: Tag[];
   externalLinks?: Tag[];
 }

--- a/packages/eventcatalog-utils/src/types.ts
+++ b/packages/eventcatalog-utils/src/types.ts
@@ -35,7 +35,7 @@ export interface FrontMatterAllowedToCopy {
 
 export interface WriteEventToCatalogOptions {
   schema?: SchemaFile;
-  codeExamples?: CodeExample[] | [];
+  codeExamples?: CodeExample[];
   useMarkdownContentFromExistingEvent?: boolean;
   markdownContent?: string;
   frontMatterToCopyToNewVersions?: FrontMatterAllowedToCopy;

--- a/packages/eventcatalog/components/Mdx/NodeGraph/GraphLayout.ts
+++ b/packages/eventcatalog/components/Mdx/NodeGraph/GraphLayout.ts
@@ -1,5 +1,6 @@
 import { isNode, Elements, Position } from 'react-flow-renderer';
 import dagre from 'dagre';
+import { DataSource } from './NodeGraph';
 
 const nodeDefaultWidth = 150;
 const nodeDefaultHeight = 36;
@@ -92,16 +93,16 @@ export default function createGraphLayout(elements: Elements, isHorizontal: bool
 }
 
 // Helper - ReactFlow canvas height calculator
-export const calcCanvasHeight = (data, type): number => {
+export const calcCanvasHeight = ({ source, data }: DataSource): number => {
   const minHeight = 300;
   const nodeSpacing = nodeDefaultHeight + verticalOffset;
   let nodesHeight = 0;
 
-  if (type === 'event') {
+  if (source === 'event') {
     nodesHeight = Math.max(data.producerNames.length, data.consumerNames.length) * nodeSpacing;
   }
 
-  if (type === 'service') {
+  if (source === 'service') {
     nodesHeight = Math.max(data.publishes.length, data.subscribes.length) * nodeSpacing;
   }
 

--- a/packages/eventcatalog/components/Mdx/NodeGraph/NodeGraph.tsx
+++ b/packages/eventcatalog/components/Mdx/NodeGraph/NodeGraph.tsx
@@ -74,9 +74,8 @@ function NodeGraphBuilder({
 }: NodeGraphBuilderProps) {
   const getElements = useCallback(() => {
     if (source === 'domain' || source === 'all') {
-      const graphData = source === 'domain' ? data : data;
-      const totalEventElements = graphData.events.map((event) => getEventElements(event, rootNodeColor, isAnimated, true, true));
-      const totalServiceElements = graphData.services.map((service) =>
+      const totalEventElements = data.events.map((event) => getEventElements(event, rootNodeColor, isAnimated, true, true));
+      const totalServiceElements = data.services.map((service) =>
         getServiceElements(service, rootNodeColor, isAnimated, true, true)
       );
       const eventsWithServices = totalEventElements.flat().concat(totalServiceElements.flat());

--- a/packages/eventcatalog/components/Mdx/NodeGraph/__tests__/GraphLayout.spec.ts
+++ b/packages/eventcatalog/components/Mdx/NodeGraph/__tests__/GraphLayout.spec.ts
@@ -1,3 +1,4 @@
+import { Event, Service } from '@eventcatalog/types';
 import { Elements } from 'react-flow-renderer';
 import createGraphLayout, { calcCanvasHeight } from '../GraphLayout';
 
@@ -84,20 +85,30 @@ describe('GraphLayout', () => {
 
   describe('calcCanvasHeight', () => {
     it('takes all events and calculate the canvas height', () => {
-      const data = {
-        producerNames: [1, 2, 3, 4, 5, 6, 7, 8],
-        consumerNames: [1, 2, 3, 4, 5],
+      const data: Event = {
+        producerNames: ['1', '2', '3', '4', '5', '6', '7', '8'],
+        consumerNames: ['1', '2', '3', '4', '5'],
+        name: 'mock',
+        version: '1.0.0',
       };
-      const result = calcCanvasHeight(data, 'event');
+      const result = calcCanvasHeight({ data, source: 'event' });
       expect(result).toEqual(544);
     });
 
     it('takes all services and calculate the canvas height', () => {
-      const data = {
-        publishes: [1, 2, 3, 4, 5, 6, 7, 8, 9],
-        subscribes: [1, 2, 3, 4, 5],
+      const event: Event = {
+        producerNames: [],
+        consumerNames: [],
+        name: 'mock',
+        version: '1.0.0',
       };
-      const result = calcCanvasHeight(data, 'service');
+      const data: Service = {
+        publishes: [event, event, event, event, event, event, event, event, event],
+        subscribes: [event, event, event, event, event],
+        name: 'mock',
+        summary: 'mock',
+      };
+      const result = calcCanvasHeight({ data, source: 'service' });
       expect(result).toEqual(612);
     });
   });

--- a/packages/eventcatalog/package.json
+++ b/packages/eventcatalog/package.json
@@ -56,7 +56,7 @@
     "postcss": "^8.3.11",
     "tailwindcss": "^2.2.19",
     "trim": "0.0.3",
-    "typescript": "^4.4.4"
+    "typescript": "^4.6.2"
   },
   "gitHead": "5f82ce7f267e9b3ec771bbd3cc81359ed0a8fd18"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20236,10 +20236,10 @@ typescript@4.3.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
-typescript@^4.4.4, typescript@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+typescript@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 typical@^2.4.2, typical@^2.6.0, typical@^2.6.1:
   version "2.6.1"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

As [mentioned on discord](https://discord.com/channels/918092420338569216/918092420338569219/948603441528328192) I tried to add a couple of bugfixes which was hindered by current typings.

In this MR I did three things:
1. update TypeScript
2. get rid of `[]` usage in array (e.g. `producerNames?: string[] | Service[] | [];`)
3. introduce union type (for `data: A | B;  source: 'a' | 'b';`)

About **2.**: A type like `string[] | Service[]` already implies that the array can be empty. `const a: string[] | Service[] = []` is completely fine. The type `[]` can actually be worse as it says _you can only be empty_. E.g. mapping over such an collection uses never `empty.map(/** never **/ item => item)`.

About **3*.*: Switching from `data: A | B;  source: 'a' | 'b';` to `{ data: A;  source: 'a'; } | { data: B;  source: 'b'; }` makes checks on `source` and further usage of `Data` type safe: `if (source === 'b') // Data has the type B`.

Look at this example:
<img width="725" alt="image" src="https://user-images.githubusercontent.com/1152805/158567040-f285427e-cd19-41ba-aa10-363d447b98f0.png">

By checking `source === 'domain' || source === 'all'` TypeScript knows the type of `data`. We don't need custom `as` usage anymore.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.
