### PR TITLE
fix(core): linking to event in domain graphs

### DIFF
--- a/packages/eventcatalog/components/Mdx/NodeGraph/NodeGraph.tsx
+++ b/packages/eventcatalog/components/Mdx/NodeGraph/NodeGraph.tsx
@@ -74,7 +74,16 @@ function NodeGraphBuilder({
 }: NodeGraphBuilderProps) {
   const getElements = useCallback(() => {
     if (source === 'domain' || source === 'all') {
-      const totalEventElements = data.events.map((event) => getEventElements(event, rootNodeColor, isAnimated, true, true));
+      const totalEventElements = data.events.map((event) =>
+        getEventElements({
+          event,
+          rootNodeColor,
+          isAnimated,
+          includeLabels: true,
+          includeNodeIcons: true,
+          source: source === 'domain' ? { type: 'domain', name: data.name } : undefined,
+        })
+      );
       const totalServiceElements = data.services.map((service) =>
         getServiceElements(service, rootNodeColor, isAnimated, true, true)
       );
@@ -85,10 +94,10 @@ function NodeGraphBuilder({
     }
 
     if (source === 'event') {
-      return getEventElements(data as Event, rootNodeColor, isAnimated, includeEdgeLabels, includeNodeIcons);
+      return getEventElements({ event: data, rootNodeColor, isAnimated, includeLabels: includeEdgeLabels, includeNodeIcons });
     }
 
-    return getServiceElements(data as Service, rootNodeColor, isAnimated, includeEdgeLabels, includeNodeIcons);
+    return getServiceElements(data, rootNodeColor, isAnimated, includeEdgeLabels, includeNodeIcons);
   }, [data, includeEdgeLabels, includeNodeIcons, isAnimated, rootNodeColor, source]);
 
   const { fitView: resetView } = useZoomPanHelper();

--- a/packages/eventcatalog/components/Mdx/NodeGraph/__tests__/GraphElements.spec.ts
+++ b/packages/eventcatalog/components/Mdx/NodeGraph/__tests__/GraphElements.spec.ts
@@ -68,7 +68,7 @@ describe('GraphElements', () => {
       const rootNodeColor = '#2563eb';
       const isAnimated = true;
 
-      const result = getEventElements(event as Event, rootNodeColor, isAnimated);
+      const result = getEventElements({ event: event as Event, rootNodeColor, isAnimated });
 
       expect(result).toMatchSnapshot();
     });
@@ -94,7 +94,7 @@ describe('GraphElements', () => {
       const rootNodeColor = '#2563eb';
       const isAnimated = true;
 
-      const result = getEventElements(event as Event, rootNodeColor, isAnimated);
+      const result = getEventElements({ event: event as Event, rootNodeColor, isAnimated });
 
       expect(result).toMatchSnapshot();
     });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix https://github.com/boyney123/eventcatalog/issues/223

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

---

This MR fixes https://github.com/boyney123/eventcatalog/issues/223. I'm not sure if more places need to be fixed however. 

E.g. this part:

```
if (source === 'domain' || source === 'all') {
      const totalEventElements = data.events.map((event) =>
        getEventElements({
          event,
          rootNodeColor,
          isAnimated,
          includeLabels: true,
          includeNodeIcons: true,
          source: source === 'domain' ? { type: 'domain', name: data.name } : undefined,
        })
      );
```

I'm not sure when `source` can be `'all'`. For now I passed `source` only to `getEventElements` when it's `'domain'`.

---

FYI: If you move comments for params out of the JSDoc comment into the type signature they are actually shown on hover in VS Code.

<img width="350" alt="image" src="https://user-images.githubusercontent.com/1152805/162200738-53d70327-52ac-400e-af4b-9797d23db6ea.png">
