### PR TITLE
fix(core): show non-latest consumers and producers

### DIFF
--- a/examples/basic/domains/Shopping/events/AddedItemToCart/index.md
+++ b/examples/basic/domains/Shopping/events/AddedItemToCart/index.md
@@ -1,6 +1,6 @@
 ---
 name: AddedItemToCart
-version: 0.0.2
+version: 0.0.3
 summary: |
   Holds information about what the user added to their shopping cart.
 producers:

--- a/examples/basic/domains/Shopping/events/AddedItemToCart/versioned/0.0.2/index.md
+++ b/examples/basic/domains/Shopping/events/AddedItemToCart/versioned/0.0.2/index.md
@@ -1,6 +1,6 @@
 ---
 name: AddedItemToCart
-version: 0.0.1
+version: 0.0.2
 summary: |
   Holds information about what the user added to their shopping cart.
 producers:

--- a/packages/eventcatalog/components/Mermaid/index.tsx
+++ b/packages/eventcatalog/components/Mermaid/index.tsx
@@ -26,14 +26,22 @@ mermaid.initialize({
   width: '100%',
 });
 
-interface MermaidProps {
-  data: Event | Service;
-  source: 'event' | 'service';
-  rootNodeColor?: string;
-  charts?: string[];
+interface MermaidEventSource {
+  data: Event;
+  source: 'event';
 }
 
-function Mermaid({ data, source = 'event', rootNodeColor, charts }: MermaidProps) {
+interface MermaidServiceSource {
+  data: Service;
+  source: 'service';
+}
+
+type MermaidProps = {
+  rootNodeColor?: string;
+  charts?: string[];
+} & (MermaidEventSource | MermaidServiceSource);
+
+function Mermaid({ data, source, rootNodeColor, charts }: MermaidProps) {
   useEffect(() => {
     mermaid.contentLoaded();
   }, []);
@@ -51,8 +59,8 @@ function Mermaid({ data, source = 'event', rootNodeColor, charts }: MermaidProps
   }
   const mermaidChart =
     source === 'event'
-      ? buildMermaidFlowChartForEvent(data as Event, rootNodeColor)
-      : buildMermaidFlowChartForService(data as Service, rootNodeColor);
+      ? buildMermaidFlowChartForEvent(data, rootNodeColor)
+      : buildMermaidFlowChartForService(data, rootNodeColor);
 
   return <div className="mermaid">{mermaidChart}</div>;
 }

--- a/packages/eventcatalog/lib/services.ts
+++ b/packages/eventcatalog/lib/services.ts
@@ -66,7 +66,7 @@ export const getServiceByName = async ({
     const { data, content } = readMarkdownFile(path.join(serviceDirectory, `index.md`));
     const service = buildService(data);
 
-    const events = getAllEvents();
+    const events = getAllEvents({ withVersions: true });
 
     const mdxSource = await serialize(content);
 

--- a/packages/eventcatalog/package.json
+++ b/packages/eventcatalog/package.json
@@ -26,6 +26,7 @@
     "@tailwindcss/forms": "^0.3.4",
     "@tailwindcss/line-clamp": "^0.2.2",
     "@tailwindcss/typography": "^0.4.1",
+    "@types/semver": "^7.3.9",
     "@types/swagger-ui-react": "^4.1.1",
     "compare-versions": "^4.1.2",
     "copy-text-to-clipboard": "^3.0.1",
@@ -43,6 +44,7 @@
     "react-flow-renderer": "^9.7.3",
     "react-force-graph-3d": "^1.21.10",
     "react-syntax-highlighter": "^15.4.5",
+    "semver": "^7.3.6",
     "swagger-ui-react": "^4.6.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5430,6 +5430,11 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.3.tgz#5798ecf1bec94eaa64db39ee52808ec0693315aa"
   integrity sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==
 
+"@types/semver@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
+  integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
+
 "@types/serve-index@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278"
@@ -14287,6 +14292,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-cache@^7.4.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.8.0.tgz#649aaeb294a56297b5cbc5d70f198dcc5ebe5747"
+  integrity sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==
+
 magic-error@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/magic-error/-/magic-error-0.0.1.tgz#95ebe658ca4a86f1aebda390cab6ea50d41bfa2a"
@@ -18561,6 +18571,13 @@ semver@^7.1.1, semver@^7.1.2, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semve
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.3.6:
+  version "7.3.6"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.6.tgz#5d73886fb9c0c6602e79440b97165c29581cbb2b"
+  integrity sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==
+  dependencies:
+    lru-cache "^7.4.0"
 
 send@0.17.1:
   version "0.17.1"


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fix https://github.com/boyney123/eventcatalog/issues/85.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

---

This is my first stab at fixing https://github.com/boyney123/eventcatalog/issues/85. I'd like to know, if this is already enough for the first iteration and if not what is missing.

Two things I noticed:

**1.**: The existing `getAllEventsAndVersionsFlattened` seems to be buggy (excluding the most recent versions, because of a line which was commented out) and not returning full events (just som fields). That's why I made `getAllEvents` to allow returning versions as well.

**2.**: I stumbled over several problems, because `noImplicitAny` is not set in the `tsconfig.json`. Am I allowed to introduce this in another PR? For example the whole implementation of `truncateNode` in `graphs.ts` didn't really made any sense currently (see my fixed version). I'm also wondering if it was actually used correctly (`centerNode` used it for `id` so I did the same for `leftNodes` and `rightNodes`, but I'd assume you want it for `name`...?).
