### PR TITLE
fix: build issues with eventcatalog core

### DIFF
--- a/.changeset/serious-beans-study.md
+++ b/.changeset/serious-beans-study.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: build issues with eventcatalog core

--- a/packages/eventcatalog/components/Mdx/NodeGraph/NodeGraph.tsx
+++ b/packages/eventcatalog/components/Mdx/NodeGraph/NodeGraph.tsx
@@ -149,6 +149,7 @@ function NodeGraph({ maxHeight, renderWithBorder = true, ...builderProps }: Node
 
   return (
     <div className={`node-graph w-full h-screen ${renderWithBorder ? borderClasses : ''}`} style={{ height: dynamicHeight }}>
+      {/* @ts-ignore */}
       <ReactFlowProvider>
         <NodeGraphBuilder {...builderProps} />
       </ReactFlowProvider>

--- a/packages/eventcatalog/components/Mdx/OpenApiSpec.tsx
+++ b/packages/eventcatalog/components/Mdx/OpenApiSpec.tsx
@@ -1,7 +1,7 @@
-import dynamic from "next/dynamic";
+import dynamic from 'next/dynamic';
 import 'swagger-ui-react/swagger-ui.css';
 
-const SwaggerUI = dynamic(import('swagger-ui-react'), {ssr: false})
+const SwaggerUI = dynamic(import('swagger-ui-react'), { ssr: false });
 
 interface OpenApiSpecProps {
   spec: string;

--- a/packages/eventcatalog/components/Mdx/OpenApiSpec.tsx
+++ b/packages/eventcatalog/components/Mdx/OpenApiSpec.tsx
@@ -1,5 +1,7 @@
-import SwaggerUI from 'swagger-ui-react';
+import dynamic from "next/dynamic";
 import 'swagger-ui-react/swagger-ui.css';
+
+const SwaggerUI = dynamic(import('swagger-ui-react'), {ssr: false})
 
 interface OpenApiSpecProps {
   spec: string;

--- a/packages/eventcatalog/pages/events/[name].tsx
+++ b/packages/eventcatalog/pages/events/[name].tsx
@@ -142,7 +142,7 @@ export default function Events(props: EventsPageProps) {
 
   const { lastModifiedDate } = markdown;
 
-  const mdxComponents = getComponents({ event, schema, examples });
+  const mdxComponents = getComponents({ event, schema, examples }) as any;
 
   return (
     <>


### PR DESCRIPTION
## Motivation

Build no longer worked for EventCatalog due to TypeScript errors and package updates.

Changes

- Fixed how OpenAPI components are imported ([Issue on swagger-ui repo](https://github.com/swagger-api/swagger-ui/issues/7970))
- React flow component changed some types, just ignoring warnings for now, locally not an issue on when building...
