### PR TITLE
feat(utils/generator-asyncapi): Add domain parsing

### DIFF
--- a/.changeset/rotten-numbers-scream.md
+++ b/.changeset/rotten-numbers-scream.md
@@ -1,5 +1,6 @@
 ---
 '@eventcatalog/utils': minor
+'@eventcatalog/plugin-doc-generator-asyncapi': minor
 ---
 
 feat(utils): Add utilities for writing and reading domains to the catalog

--- a/.changeset/rotten-numbers-scream.md
+++ b/.changeset/rotten-numbers-scream.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/utils': minor
+---
+
+feat(utils): Add utilities for writing and reading domains to the catalog

--- a/.changeset/tall-dogs-pretend.md
+++ b/.changeset/tall-dogs-pretend.md
@@ -1,5 +1,0 @@
----
-'@eventcatalog/plugin-doc-generator-asyncapi': minor
----
-
-feat(generator-asyncapi): Add options for parsing AsyncAPI files into domains

--- a/.changeset/tall-dogs-pretend.md
+++ b/.changeset/tall-dogs-pretend.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/plugin-doc-generator-asyncapi': minor
+---
+
+feat(generator-asyncapi): Add options for parsing AsyncAPI files into domains

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
@@ -418,10 +418,12 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
           // just wait for files to be there in time.
           await new Promise((r) => setTimeout(r, 200));
 
+          const { getDomainFromCatalog } = utils({ catalogDirectory: process.env.PROJECT_DIR });
           const { getEventFromCatalog, getServiceFromCatalog } = utils({ catalogDirectory: path.join(process.env.PROJECT_DIR, 'domains', options.domainName) });
 
           const { raw: eventFile } = getEventFromCatalog('UserSignedUp');
           const { raw: serviceFile } = getServiceFromCatalog('Account Service');
+          const { raw: domainFile } = getDomainFromCatalog('My Domain');
 
           expect(eventFile).toMatchMarkdown(`
             ---
@@ -446,6 +448,15 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
 
             <NodeGraph />`
           );
+
+          expect(domainFile).toMatchMarkdown(`
+            ---
+            name: 'My Domain'
+            summary: 'A summary of my domain.'
+            ---
+
+            <NodeGraph />
+          `);
         });
       });
     });

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
@@ -402,6 +402,52 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
           );
         });
       });
+
+      describe('In domain AsyncAPI parsing', () => {
+        it('Creates a domain with contained services and events when domain options are set', async () => {
+          const options: AsyncAPIPluginOptions = {
+            pathToSpec: path.join(__dirname, './assets/valid-asyncapi.yml'),
+            renderMermaidDiagram: false,
+            renderNodeGraph: true,
+            domainName: 'My Domain',
+            domainSummary: 'A summary of my domain.'
+          };
+
+          await plugin(pluginContext, options);
+
+          // just wait for files to be there in time.
+          await new Promise((r) => setTimeout(r, 200));
+
+          const { getEventFromCatalog, getServiceFromCatalog } = utils({ catalogDirectory: path.join(process.env.PROJECT_DIR, 'domains', options.domainName) });
+
+          const { raw: eventFile } = getEventFromCatalog('UserSignedUp');
+          const { raw: serviceFile } = getServiceFromCatalog('Account Service');
+
+          expect(eventFile).toMatchMarkdown(`
+            ---
+              name: UserSignedUp
+              summary: null
+              version: 1.0.0
+              producers:
+                  - 'Account Service'
+              consumers: []
+              externalLinks: []
+            ---
+
+            <NodeGraph />
+            <Schema />
+            `);
+
+          expect(serviceFile).toMatchMarkdown(
+            `---
+            name: 'Account Service'
+            summary: 'This service is in charge of processing user signups'
+            ---
+
+            <NodeGraph />`
+          );
+        });
+      });
     });
   });
 });

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/__tests__/plugin.spec.ts
@@ -410,7 +410,7 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
             renderMermaidDiagram: false,
             renderNodeGraph: true,
             domainName: 'My Domain',
-            domainSummary: 'A summary of my domain.'
+            domainSummary: 'A summary of my domain.',
           };
 
           await plugin(pluginContext, options);
@@ -419,7 +419,9 @@ describe('eventcatalog-plugin-generator-asyncapi', () => {
           await new Promise((r) => setTimeout(r, 200));
 
           const { getDomainFromCatalog } = utils({ catalogDirectory: process.env.PROJECT_DIR });
-          const { getEventFromCatalog, getServiceFromCatalog } = utils({ catalogDirectory: path.join(process.env.PROJECT_DIR, 'domains', options.domainName) });
+          const { getEventFromCatalog, getServiceFromCatalog } = utils({
+            catalogDirectory: path.join(process.env.PROJECT_DIR, 'domains', options.domainName),
+          });
 
           const { raw: eventFile } = getEventFromCatalog('UserSignedUp');
           const { raw: serviceFile } = getServiceFromCatalog('Account Service');

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
@@ -1,7 +1,8 @@
 import chalk from 'chalk';
-import type { Event, Service, LoadContext } from '@eventcatalog/types';
+import type { Event, Service, LoadContext, Domain } from '@eventcatalog/types';
 import { parse, AsyncAPIDocument } from '@asyncapi/parser';
 import fs from 'fs-extra';
+import path from 'path';
 import utils from '@eventcatalog/utils';
 
 import type { AsyncAPIPluginOptions } from './types';
@@ -47,7 +48,7 @@ const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument, options: AsyncAPIPlugin
 };
 
 const parseAsyncAPIFile = async (pathToFile: string, options: AsyncAPIPluginOptions, copyFrontMatter: boolean) => {
-  const { versionEvents = true, renderMermaidDiagram = true, renderNodeGraph = false } = options;
+  const { versionEvents = true, renderMermaidDiagram = true, renderNodeGraph = false, domainName = '', domainSummary = '' } = options;
 
   let asyncAPIFile;
 
@@ -67,7 +68,22 @@ const parseAsyncAPIFile = async (pathToFile: string, options: AsyncAPIPluginOpti
     throw new Error('Please provide catalog url (env variable PROJECT_DIR)');
   }
 
-  const { writeServiceToCatalog, writeEventToCatalog } = utils({ catalogDirectory: process.env.PROJECT_DIR });
+  if (domainName) {
+    const { writeDomainToCatalog } = utils({ catalogDirectory: process.env.PROJECT_DIR });
+
+    const domain: Domain = {
+      name: domainName,
+      summary: domainSummary
+    };
+
+    await writeDomainToCatalog(domain, {
+      useMarkdownContentFromExistingDomain: true,
+      renderMermaidDiagram,
+      renderNodeGraph
+    });
+  }
+
+  const { writeServiceToCatalog, writeEventToCatalog } = utils({ catalogDirectory: domainName ? path.join(process.env.PROJECT_DIR, 'domains', domainName) : process.env.PROJECT_DIR });
 
   await writeServiceToCatalog(service, {
     useMarkdownContentFromExistingService: true,

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
@@ -48,7 +48,13 @@ const getAllEventsFromAsyncDoc = (doc: AsyncAPIDocument, options: AsyncAPIPlugin
 };
 
 const parseAsyncAPIFile = async (pathToFile: string, options: AsyncAPIPluginOptions, copyFrontMatter: boolean) => {
-  const { versionEvents = true, renderMermaidDiagram = true, renderNodeGraph = false, domainName = '', domainSummary = '' } = options;
+  const {
+    versionEvents = true,
+    renderMermaidDiagram = true,
+    renderNodeGraph = false,
+    domainName = '',
+    domainSummary = '',
+  } = options;
 
   let asyncAPIFile;
 
@@ -73,17 +79,19 @@ const parseAsyncAPIFile = async (pathToFile: string, options: AsyncAPIPluginOpti
 
     const domain: Domain = {
       name: domainName,
-      summary: domainSummary
+      summary: domainSummary,
     };
 
     await writeDomainToCatalog(domain, {
       useMarkdownContentFromExistingDomain: true,
       renderMermaidDiagram,
-      renderNodeGraph
+      renderNodeGraph,
     });
   }
 
-  const { writeServiceToCatalog, writeEventToCatalog } = utils({ catalogDirectory: domainName ? path.join(process.env.PROJECT_DIR, 'domains', domainName) : process.env.PROJECT_DIR });
+  const { writeServiceToCatalog, writeEventToCatalog } = utils({
+    catalogDirectory: domainName ? path.join(process.env.PROJECT_DIR, 'domains', domainName) : process.env.PROJECT_DIR,
+  });
 
   await writeServiceToCatalog(service, {
     useMarkdownContentFromExistingService: true,

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/types.ts
@@ -4,4 +4,6 @@ export type AsyncAPIPluginOptions = {
   externalAsyncAPIUrl?: string;
   renderMermaidDiagram?: boolean;
   renderNodeGraph?: boolean;
+  domainName?: string;
+  domainSummary?: string;
 };

--- a/packages/eventcatalog-utils/src/__tests__/assets/catalog/domains/My Domain That Already Exists/index.md
+++ b/packages/eventcatalog-utils/src/__tests__/assets/catalog/domains/My Domain That Already Exists/index.md
@@ -1,0 +1,7 @@
+---
+name: 'My Domain That Already Exists'
+summary: 'This is a summary for my domain'
+owners:
+    - dBoyne
+---
+# Content already exists

--- a/packages/eventcatalog-utils/src/__tests__/assets/catalog/domains/Orders/index.md
+++ b/packages/eventcatalog-utils/src/__tests__/assets/catalog/domains/Orders/index.md
@@ -1,0 +1,9 @@
+---
+name: Orders
+summary: |
+  Domain that holds all the order information.
+owners:
+    - dboyne
+---
+
+# Testing

--- a/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
+++ b/packages/eventcatalog-utils/src/__tests__/utils.spec.ts
@@ -866,7 +866,7 @@ describe('eventcatalog-utils', () => {
         expect(data).toEqual({
           name: 'Orders',
           summary: 'Domain that holds all the order information.\n',
-          owners: ['dboyne']
+          owners: ['dboyne'],
         });
 
         expect(content).toMatchMarkdown('# Testing');
@@ -976,7 +976,7 @@ describe('eventcatalog-utils', () => {
           summary: 'This is a summary for my domain',
           owners: ['dBoyne'],
         };
-        
+
         const { path: domainPath } = writeDomainToCatalog(domain, { useMarkdownContentFromExistingDomain: true });
 
         // expect(fs.existsSync(domainPath)).toEqual(true);

--- a/packages/eventcatalog-utils/src/domains.ts
+++ b/packages/eventcatalog-utils/src/domains.ts
@@ -1,0 +1,72 @@
+import path from 'path';
+import fs from 'fs-extra';
+import matter from 'gray-matter';
+import { Domain } from '@eventcatalog/types';
+import buildMarkdownFile from './markdown-builder';
+
+import { FunctionInitInterface, WriteDomainToCatalogOptions, WriteDomainToCatalogResponse } from './types';
+
+const readMarkdownFile = (pathToFile: string) => {
+  const file = fs.readFileSync(pathToFile, {
+    encoding: 'utf-8',
+  });
+  return {
+    parsed: matter(file),
+    raw: file,
+  };
+};
+
+export const getDomainFromCatalog =
+  ({ catalogDirectory }: FunctionInitInterface) =>
+  (domainName: string) => {
+    try {
+      // Read the directory to get the stuff we need.
+      const { parsed: parsedService, raw } = readMarkdownFile(path.join(catalogDirectory, 'domains', domainName, 'index.md'));
+      return {
+        data: parsedService.data,
+        content: parsedService.content,
+        raw,
+      };
+    } catch (error) {
+      return null;
+    }
+  };
+
+export const buildDomainMarkdownForCatalog =
+  () =>
+  (domain: Domain, { markdownContent, renderMermaidDiagram = true, renderNodeGraph = false }: any = {}) =>
+    buildMarkdownFile({
+      frontMatterObject: domain,
+      customContent: markdownContent,
+      renderMermaidDiagram,
+      renderNodeGraph,
+    });
+
+export const writeDomainToCatalog =
+  ({ catalogDirectory }: FunctionInitInterface) =>
+  (domain: Domain, options?: WriteDomainToCatalogOptions): WriteDomainToCatalogResponse => {
+    const { name: domainName } = domain;
+    const { useMarkdownContentFromExistingDomain = true, renderMermaidDiagram = true, renderNodeGraph = false } = options || {};
+    let markdownContent;
+
+    if (!domainName) throw new Error('No `name` found for given domain');
+
+    if (useMarkdownContentFromExistingDomain) {
+      const data = getDomainFromCatalog({ catalogDirectory })(domainName);
+      markdownContent = data?.content ? data?.content : '';
+    }
+
+    const data = buildDomainMarkdownForCatalog()(domain, {
+      markdownContent,
+      useMarkdownContentFromExistingDomain,
+      renderMermaidDiagram,
+      renderNodeGraph,
+    });
+
+    fs.ensureDirSync(path.join(catalogDirectory, 'domains', domain.name));
+    fs.writeFileSync(path.join(catalogDirectory, 'domains', domain.name, 'index.md'), data);
+
+    return {
+      path: path.join(catalogDirectory, 'domains', domain.name),
+    };
+  };

--- a/packages/eventcatalog-utils/src/index.ts
+++ b/packages/eventcatalog-utils/src/index.ts
@@ -15,11 +15,7 @@ import {
   getAllServicesFromCatalog,
   getServiceFromCatalog,
 } from './services';
-import {
-  getDomainFromCatalog,
-  writeDomainToCatalog,
-  buildDomainMarkdownForCatalog,
-} from './domains';
+import { getDomainFromCatalog, writeDomainToCatalog, buildDomainMarkdownForCatalog } from './domains';
 
 interface ExistsInCatalogInterface {
   type: 'service' | 'event';

--- a/packages/eventcatalog-utils/src/index.ts
+++ b/packages/eventcatalog-utils/src/index.ts
@@ -15,6 +15,11 @@ import {
   getAllServicesFromCatalog,
   getServiceFromCatalog,
 } from './services';
+import {
+  getDomainFromCatalog,
+  writeDomainToCatalog,
+  buildDomainMarkdownForCatalog,
+} from './domains';
 
 interface ExistsInCatalogInterface {
   type: 'service' | 'event';
@@ -36,11 +41,16 @@ const utils = ({ catalogDirectory }: FunctionInitInterface) => ({
   getAllEventsFromCatalog: getAllEventsFromCatalog({ catalogDirectory }),
   versionEvent: versionEvent({ catalogDirectory }),
 
-  // service funs
+  // service funcs
   writeServiceToCatalog: writeServiceToCatalog({ catalogDirectory }),
   buildServiceMarkdownForCatalog: buildServiceMarkdownForCatalog(),
   getServiceFromCatalog: getServiceFromCatalog({ catalogDirectory }),
   getAllServicesFromCatalog: getAllServicesFromCatalog({ catalogDirectory }),
+
+  // domain funcs
+  getDomainFromCatalog: getDomainFromCatalog({ catalogDirectory }),
+  writeDomainToCatalog: writeDomainToCatalog({ catalogDirectory }),
+  buildDomainMarkdownForCatalog: buildDomainMarkdownForCatalog(),
 
   // generic
   existsInCatalog: existsInCatalog({ catalogDirectory }),

--- a/packages/eventcatalog-utils/src/markdown-builder.ts
+++ b/packages/eventcatalog-utils/src/markdown-builder.ts
@@ -1,6 +1,6 @@
 import YAML from 'yamljs';
 import json2md from 'json2md';
-import { Event, Service } from '@eventcatalog/types';
+import { Event, Service, Domain } from '@eventcatalog/types';
 
 export default ({
   frontMatterObject,
@@ -9,7 +9,7 @@ export default ({
   renderMermaidDiagram = true,
   renderNodeGraph = false,
 }: {
-  frontMatterObject: Service | Event;
+  frontMatterObject: Service | Event | Domain;
   customContent?: string;
   includeSchemaComponent?: boolean;
   renderMermaidDiagram?: boolean;

--- a/packages/eventcatalog-utils/src/types.ts
+++ b/packages/eventcatalog-utils/src/types.ts
@@ -45,3 +45,13 @@ export interface WriteEventToCatalogOptions {
   frontMatterToCopyToNewVersions?: FrontMatterAllowedToCopy;
   versionExistingEvent?: boolean;
 }
+
+export interface WriteDomainToCatalogOptions {
+  useMarkdownContentFromExistingDomain?: boolean;
+  renderMermaidDiagram?: boolean;
+  renderNodeGraph?: boolean;
+}
+
+export interface WriteDomainToCatalogResponse {
+  path: string;
+}

--- a/website/docs/api/plugins/plugin-doc-generator-asyncapi.md
+++ b/website/docs/api/plugins/plugin-doc-generator-asyncapi.md
@@ -48,6 +48,10 @@ npm install --save @eventcatalog/plugin-doc-generator-asyncapi
 | `externalAsyncAPIUrl` | `string` | `` | When a AsyncAPI base url is set the, a external link to the AsyncAPI message documentation will be added to each event. |
 | `renderMermaidDiagram` | `boolean` | true | When set to true it will render the [Mermaid](/docs/components/overview#mermaid-) diagrams to matched events from AsyncAPI file. |
 | `renderNodeGraph` | `boolean` | false | When set to true is will render the [NodeGraph](/docs/components/overview#nodegraph-) diagram to the matched events from the AsyncAPI file. |
+| `domainName` | `string` | `` | The name of the [Domain](/docs/guides/domains/domains-adding-domains) into which to place the events and services parsed from the AsyncAPI document(s). |
+| `domainSummary` | `string` | `` | Summary description of the domain. |
+
+In the case
 
 </APITable>
 
@@ -79,3 +83,40 @@ module.exports = {
 
 This will read the `asyncapi.yml` file in the root of your project. You can provide whatever path you wish.
 
+### What if I want to parse AsyncAPI files into different domains?
+
+If you want to specify several different domains into which different sets of AsyncAPI files should be parsed then you should use multiple AsyncAPI plugin instances in the `generators` array where each generator listed with a `domainName` will map to a unique domain into which the AsyncAPI file listed under the `pathToSpec` property will be parsed.
+
+```js title="eventcatalog.config.js"
+
+const path = require('path');
+
+module.exports = {
+   generators: [
+    // first generator pushes parsed files into the Orders domain
+    [
+      '@eventcatalog/plugin-doc-generator-asyncapi',
+      {
+        // path to your AsyncAPI files
+        pathToSpec: [path.join(__dirname, 'asyncapi-order-created.yml')],
+
+        // version events if already in catalog (optional)
+        versionEvents: true,
+        domainName: 'Orders'
+      },
+    ],
+    // second generator pushes parsed files in the Payments domain
+    [
+      '@eventcatalog/plugin-doc-generator-asyncapi',
+      {
+        // path to your AsyncAPI files
+        pathToSpec: [path.join(__dirname, 'asyncapi-payments-processed.yml')],
+
+        // version events if already in catalog (optional)
+        versionEvents: true,
+        domainName: 'Payments'
+      },
+    ],
+  ],
+};
+```


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Eventcatalog does not currently support the interop of AsyncAPI documents into domain boundaries. This functionality is also not supported directly by the AsyncAPI spec and so it makes sense to include the domain boundaries as part of the eventcatalog config rather than trying to develop a new standard for domain boundaries using `x-properties` in the AsyncAPI document. 

To this end, if users would like to break up their AsyncAPI document parsing by domain then each generator in the `generators` field of the `eventcatalog.config.js` file can map to each domain required. If domains are not included then the generator works as before and pushes services and events into the "global" catalog.

A usage example for this would be:
```js
// eventcatalog.config.js
const path = require('path');

module.exports = {
   generators: [
    // first generator pushes parsed files into the Orders domain
    [
      '@eventcatalog/plugin-doc-generator-asyncapi',
      {
        // path to your AsyncAPI files
        pathToSpec: [path.join(__dirname, 'asyncapi-order-created.yml'), path.join(__dirname, 'asyncapi-order-deleted.yml')],

        // version events if already in catalog (optional)
        versionEvents: true,
        domainName: 'Orders'
      },
    ],
    // second generator pushes parsed files in the Payments domain
    [
      '@eventcatalog/plugin-doc-generator-asyncapi',
      {
        // path to your AsyncAPI files
        pathToSpec: [path.join(__dirname, 'asyncapi-payments-processed.yml')],

        // version events if already in catalog (optional)
        versionEvents: true,
        domainName: 'Payments'
      },
    ],
  ],
};
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes 🐒
