### PR TITLE
fix: Broken link behind event's View in Visualiser button

### DIFF
--- a/.changeset/eleven-hairs-serve.md
+++ b/.changeset/eleven-hairs-serve.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+Fix a broken link behind View in Visualiser button on the Event Details page

--- a/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
+++ b/packages/eventcatalog/components/Sidebars/EventSidebar.tsx
@@ -154,7 +154,7 @@ function EventSideBar({ event, loadedVersion, isOldVersion, urlPath }: EventSide
           </Link>
         )}
 
-        <Link href={`/visualiser?type=event&name${eventName}`}>
+        <Link href={`/visualiser?type=event&name=${eventName}`}>
           <a className="hidden w-full md:inline-flex h-10 justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-800 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-200">
             <span>View in Visualiser</span>
           </a>


### PR DESCRIPTION
## Motivation

I have recently discovered the Event Catalog for our team and found a minor bug, which appeared to be an easy one to fix.
This PR fixed #279.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes