### PR TITLE
feat - users can now edit header links

### DIFF
--- a/.changeset/tough-crews-count.md
+++ b/.changeset/tough-crews-count.md
@@ -1,0 +1,6 @@
+---
+"@eventcatalog/types": minor
+"@eventcatalog/core": minor
+---
+
+feat - users can now edit header links

--- a/examples/basic/eventcatalog.config.js
+++ b/examples/basic/eventcatalog.config.js
@@ -8,6 +8,13 @@ module.exports = {
     alt: 'EventCatalog Logo',
     src: 'logo.svg'
   },
+  headerLinks: [
+    { label: 'Events', href: '/events'},
+    { label: 'Services', href: '/services' },
+    { label: 'Domains', href: '/domains'},
+    { label: 'Visualiser', href: '/visualiser' },
+    { label: '3D Node Graph', href: '/overview' },
+  ],
   footerLinks: [
     { label: 'Events', href: '/events' },
     { label: 'Services', href: '/services' },

--- a/packages/eventcatalog-types/src/index.d.ts
+++ b/packages/eventcatalog-types/src/index.d.ts
@@ -98,6 +98,7 @@ export interface EventCatalogConfig {
   generators?: PluginConfig[] | [] | any;
   footerLinks?: Link[];
   homepageLink?: string;
+  headerLinks?: Link[]
   openGraph?: OpenGraphConfig;
   analytics?: AnalyticsConfig;
 }

--- a/packages/eventcatalog-types/src/index.d.ts
+++ b/packages/eventcatalog-types/src/index.d.ts
@@ -98,7 +98,7 @@ export interface EventCatalogConfig {
   generators?: PluginConfig[] | [] | any;
   footerLinks?: Link[];
   homepageLink?: string;
-  headerLinks?: Link[]
+  headerLinks?: Link[];
   openGraph?: OpenGraphConfig;
   analytics?: AnalyticsConfig;
 }

--- a/packages/eventcatalog/components/Header.tsx
+++ b/packages/eventcatalog/components/Header.tsx
@@ -3,12 +3,12 @@ import getConfig from 'next/config';
 import { useRouter } from 'next/router';
 import { useConfig } from '@/hooks/EventCatalog';
 
-const navigation = [
-  { name: 'Events', href: '/events' },
-  { name: 'Services', href: '/services' },
-  { name: 'Domains', href: '/domains' },
-  { name: 'Visualiser', href: '/visualiser' },
-  { name: '3D Node Graph', href: '/overview' },
+const defaultNavigation = [
+  { label: 'Events', href: '/events'},
+  { label: 'Services', href: '/services' },
+  { label: 'Domains', href: '/domains'},
+  { label: 'Visualiser', href: '/visualiser' },
+  { label: '3D Node Graph', href: '/overview' },
 ];
 
 function classNames(...classes) {
@@ -16,11 +16,14 @@ function classNames(...classes) {
 }
 
 export default function Example() {
-  const { title, homepageLink, logo } = useConfig();
+  const { title, homepageLink, logo, headerLinks: configNavigation } = useConfig();
   const router = useRouter();
 
   const { publicRuntimeConfig: { basePath = '' } = {} } = getConfig();
   const logoToLoad = logo || { alt: 'EventCatalog Logo', src: `logo.svg` };
+
+  const headerNavigation = configNavigation || defaultNavigation;
+
 
   return (
     <div className="bg-gray-800">
@@ -46,10 +49,10 @@ export default function Example() {
           </div>
           <div className="hidden sm:block sm:ml-6">
             <div className="flex space-x-4">
-              {navigation.map((item) => {
+              {headerNavigation.map((item) => {
                 const current = router.pathname === item.href;
                 return (
-                  <Link key={item.name} href={item.href}>
+                  <Link key={item.label} href={item.href}>
                     <a
                       className={classNames(
                         current ? 'bg-gray-900 text-white' : 'text-gray-300 hover:bg-gray-700 hover:text-white',
@@ -57,7 +60,7 @@ export default function Example() {
                       )}
                       aria-current={current ? 'page' : undefined}
                     >
-                      {item.name}
+                      {item.label}
                     </a>
                   </Link>
                 );

--- a/packages/eventcatalog/components/Header.tsx
+++ b/packages/eventcatalog/components/Header.tsx
@@ -4,9 +4,9 @@ import { useRouter } from 'next/router';
 import { useConfig } from '@/hooks/EventCatalog';
 
 const defaultNavigation = [
-  { label: 'Events', href: '/events'},
+  { label: 'Events', href: '/events' },
   { label: 'Services', href: '/services' },
-  { label: 'Domains', href: '/domains'},
+  { label: 'Domains', href: '/domains' },
   { label: 'Visualiser', href: '/visualiser' },
   { label: '3D Node Graph', href: '/overview' },
 ];
@@ -23,7 +23,6 @@ export default function Example() {
   const logoToLoad = logo || { alt: 'EventCatalog Logo', src: `logo.svg` };
 
   const headerNavigation = configNavigation || defaultNavigation;
-
 
   return (
     <div className="bg-gray-800">

--- a/website/docs/api/eventcatalog.config.js.md
+++ b/website/docs/api/eventcatalog.config.js.md
@@ -37,7 +37,6 @@ module.exports = {
 };
 ```
 
-
 ## Optional fields {#optional-fields}
 
 ### `editUrl` {#editUrl}
@@ -119,6 +118,30 @@ module.exports = {
 };
 ```
 
+### `headerLinks` {#header-links}
+
+- Type: `Link[]`
+
+- Type: `Link`
+  - `label`: value that gets rendered on the UI
+  - `href`: URL for link
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  headerLinks: [
+    { label: 'Events', href: '/events' },
+    { label: 'Services', href: '/services' },
+    { label: 'Domains', href: '/domains' },
+    { label: 'Visualiser', href: '/visualiser' },
+    { label: '3D Node Graph', href: '/overview' },
+  ],
+};
+```
+
+:::tip Adding or Removing Pages from the Navigation Bar
+Using the `headerLinks` configuration you can add or remove any links you like in your header bar. If you want to remove a link to the page simplify just remove that item from the array.
+:::
+
 ### `footerLinks` {#footer-links}
 
 - Type: `FooterLink[]`
@@ -144,7 +167,7 @@ module.exports = {
 
 ```js title="eventcatalog.config.js"
 module.exports = {
-  analytics: { googleAnalyticsTrackingId: 'GA-XXXXX-X' }
+  analytics: { googleAnalyticsTrackingId: 'GA-XXXXX-X' },
 };
 ```
 


### PR DESCRIPTION
## Motivation

Fix for #269

We already have `footerLinks` that allow users to edit footer urls, now users of EventCatalog can now edit header links using EventCatalog.config file.

If no values are provided in the config file, it will default to what it originally has been.


