### PR TITLE
fix - allow button configuration on the homescreen

### DIFF
--- a/.changeset/five-cobras-serve.md
+++ b/.changeset/five-cobras-serve.md
@@ -1,0 +1,7 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+"@eventcatalog/types": patch
+"@eventcatalog/core": patch
+---
+
+fix - allow button configuration on the homescreen

--- a/examples/basic/eventcatalog.config.js
+++ b/examples/basic/eventcatalog.config.js
@@ -8,6 +8,14 @@ module.exports = {
     alt: 'EventCatalog Logo',
     src: 'logo.svg'
   },
+  primaryCTA: {
+    label: 'Explore Events',
+    href: '/events'
+  },
+  secondaryCTA: {
+    label: 'Getting Started',
+    href:"https://www.eventcatalog.dev/"
+  },
   headerLinks: [
     { label: 'Events', href: '/events'},
     { label: 'Services', href: '/services' },

--- a/packages/create-eventcatalog/templates/default/eventcatalog.config.js
+++ b/packages/create-eventcatalog/templates/default/eventcatalog.config.js
@@ -5,6 +5,14 @@ module.exports = {
   projectName: 'Event Catalog',
   editUrl: 'https://github.com/boyney123/eventcatalog-demo/edit/master',
   trailingSlash: true,
+  primaryCTA: {
+    label: 'Explore Events',
+    href: '/events'
+  },
+  secondaryCTA: {
+    label: 'Getting Started',
+    href:"https://www.eventcatalog.dev/"
+  },
   logo: {
     alt: 'EventCatalog Logo',
     // found in the public dir

--- a/packages/eventcatalog-types/src/index.d.ts
+++ b/packages/eventcatalog-types/src/index.d.ts
@@ -91,6 +91,8 @@ export interface AnalyticsConfig {
 export interface EventCatalogConfig {
   title: string;
   tagline?: string;
+  primaryCTA?: Link;
+  secondaryCTA?: Link;
   editUrl?: string;
   organizationName: string;
   logo?: { alt: string; src: string };

--- a/packages/eventcatalog/pages/index.tsx
+++ b/packages/eventcatalog/pages/index.tsx
@@ -5,7 +5,7 @@ import getConfig from 'next/config';
 import { useConfig } from '@/hooks/EventCatalog';
 
 export default function Example() {
-  const { title, tagline, logo } = useConfig();
+  const { title, tagline, logo, primaryCTA = { label: 'Explore Events', href: '/events' }, secondaryCTA } = useConfig();
 
   const { publicRuntimeConfig: { basePath = '' } = {} } = getConfig();
   const logoToLoad = logo || { alt: 'EventCatalog Logo', src: `logo.svg` };
@@ -18,22 +18,36 @@ export default function Example() {
         {tagline && <p className="mt-2 text-lg font-medium text-white">{tagline}</p>}
         <div className="mt-5 max-w-md mx-auto sm:flex sm:justify-center md:mt-8">
           <div className="rounded-md shadow">
-            <Link href="/events">
+            <Link href={primaryCTA.href}>
               <a className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 md:py-4 md:text-lg md:px-10">
-                Explore Events
+                {primaryCTA.label}
               </a>
             </Link>
           </div>
-          <div className="mt-3 rounded-md shadow sm:mt-0 sm:ml-3">
-            <a
-              href="https://eventcatalog.dev"
-              target="_blank"
-              className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-indigo-600 bg-white hover:bg-gray-50 md:py-4 md:text-lg md:px-10"
-              rel="noreferrer"
-            >
-              Getting Started
-            </a>
-          </div>
+          {secondaryCTA && (
+            <div className="mt-3 rounded-md shadow sm:mt-0 sm:ml-3">
+              {secondaryCTA.href.includes('http') && (
+                <a
+                  href={secondaryCTA.href}
+                  target="_blank"
+                  className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-indigo-600 bg-white hover:bg-gray-50 md:py-4 md:text-lg md:px-10"
+                  rel="noreferrer"
+                >
+                  {secondaryCTA.label}
+                </a>
+              )}
+              {!secondaryCTA.href.includes('http') && (
+                <Link href={secondaryCTA.href}>
+                  <a
+                    className="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-indigo-600 bg-white hover:bg-gray-50 md:py-4 md:text-lg md:px-10"
+                    rel="noreferrer"
+                  >
+                    {secondaryCTA.label}
+                  </a>
+                </Link>
+              )}
+            </div>
+          )}
         </div>
         <div className="mt-6 space-x-5" />
       </div>

--- a/website/docs/api/eventcatalog.config.js.md
+++ b/website/docs/api/eventcatalog.config.js.md
@@ -90,6 +90,40 @@ module.exports = {
 };
 ```
 
+### `primaryCTA` {#primaryCTA}
+
+- Type: `Link`
+
+The primary call to action seen on the homescreen of EventCatalog. You can override the default by passing in the `primaryCTA` into your config file. 
+
+It will always default to `Explore Events` if you do not specify the primaryCTA.
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  primaryCTA: {
+    'href': "/events",
+    'label': "Explore Events"
+  }
+};
+```
+
+### `secondaryCTA` {#secondaryCTA}
+
+- Type: `Link`
+
+The secondary call to action seen on the homescreen of EventCatalog. You can set this to any internal EventCatalog page or external URL you want.
+
+If you do not pass in the `secondaryCTA` value, then no button will be shown.
+
+```js title="eventcatalog.config.js"
+module.exports = {
+  secondaryCTA: {
+    'href': "/services",
+    'label': "Explore Services"
+  }
+};
+```
+
 ### `users` {#users}
 
 Add user information here. You can reference these inside your Event and Service markdown files.


### PR DESCRIPTION


## Motivation

#275 , the buttons on the homescreen can now be edited. If you want to remove the `Getting Started` button then you can choose not to pass in the `secondaryCTA` into the config file.
