### PR TITLE
Mermaid component type error breaks build

### DIFF
--- a/.changeset/loud-tips-sell.md
+++ b/.changeset/loud-tips-sell.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Mermaid component not working

--- a/packages/eventcatalog/components/Mermaid/index.tsx
+++ b/packages/eventcatalog/components/Mermaid/index.tsx
@@ -9,7 +9,6 @@ mermaid.initialize({
   securityLevel: 'loose',
   flowchart: {
     useMaxWidth: false,
-    width: '1000px',
   },
   themeCSS: `
   .node {
@@ -23,7 +22,6 @@ mermaid.initialize({
   }
     `,
   fontFamily: 'Fira Code',
-  width: '100%',
 });
 
 interface MermaidProps {


### PR DESCRIPTION
Hi! The `width` property usage here will break the build as the types are not compatible/expecting these keys. Removing them makes it all work and build as expected.