### PR TITLE
fix: check if is not file when expect folder

### DIFF
--- a/packages/eventcatalog-utils/src/events.ts
+++ b/packages/eventcatalog-utils/src/events.ts
@@ -26,161 +26,161 @@ const readMarkdownFile = (pathToFile: string) => {
 
 export const getEventFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  (eventName: string) => {
-    if (!existsInCatalog({ catalogDirectory })(eventName, { type: 'event' })) {
-      return null;
-    }
+    (eventName: string) => {
+      if (!existsInCatalog({ catalogDirectory })(eventName, { type: 'event' })) {
+        return null;
+      }
 
-    // Read the directory to get the stuff we need.
-    const { parsed: parsedEvent, raw } = readMarkdownFile(path.join(catalogDirectory, 'events', eventName, 'index.md'));
+      // Read the directory to get the stuff we need.
+      const { parsed: parsedEvent, raw } = readMarkdownFile(path.join(catalogDirectory, 'events', eventName, 'index.md'));
 
-    return {
-      data: parseEventFrontMatterIntoEvent(parsedEvent.data),
-      content: parsedEvent.content,
-      raw,
+      return {
+        data: parseEventFrontMatterIntoEvent(parsedEvent.data),
+        content: parsedEvent.content,
+        raw,
+      };
     };
-  };
 
 export const getAllEventsFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  () => {
-    const eventsDir = path.join(catalogDirectory, 'events');
-    const folders = fs.readdirSync(eventsDir);
-    const events = folders.map((folder) => getEventFromCatalog({ catalogDirectory })(folder));
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    return events.filter((event) => event !== null).map(({ raw, ...event }: any) => event);
-  };
+    () => {
+      const eventsDir = path.join(catalogDirectory, 'events');
+      const folders = fs.readdirSync(eventsDir);
+      const events = folders.filter((folder) => { return fs.lstatSync(folder).isDirectory() }).map((folder) => getEventFromCatalog({ catalogDirectory })(folder));
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      return events.filter((event) => event !== null).map(({ raw, ...event }: any) => event);
+    };
 
 export const buildEventMarkdownForCatalog =
   () =>
-  (
-    event: Event,
-    { markdownContent, includeSchemaComponent, renderMermaidDiagram, renderNodeGraph, defaultFrontMatter = {} }: any = {}
-  ) => {
-    const frontMatter = merge(event, defaultFrontMatter);
-    return buildMarkdownFile({
-      frontMatterObject: frontMatter,
-      customContent: markdownContent,
-      includeSchemaComponent,
-      renderMermaidDiagram,
-      renderNodeGraph,
-    });
-  };
+    (
+      event: Event,
+      { markdownContent, includeSchemaComponent, renderMermaidDiagram, renderNodeGraph, defaultFrontMatter = {} }: any = {}
+    ) => {
+      const frontMatter = merge(event, defaultFrontMatter);
+      return buildMarkdownFile({
+        frontMatterObject: frontMatter,
+        customContent: markdownContent,
+        includeSchemaComponent,
+        renderMermaidDiagram,
+        renderNodeGraph,
+      });
+    };
 
 export const versionEvent =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  (eventName: string, { removeOnVersion = true } = {}) => {
-    const eventPath = path.join(catalogDirectory, 'events', eventName);
-    const versionedPath = path.join(catalogDirectory, 'events', eventName, 'versioned');
+    (eventName: string, { removeOnVersion = true } = {}) => {
+      const eventPath = path.join(catalogDirectory, 'events', eventName);
+      const versionedPath = path.join(catalogDirectory, 'events', eventName, 'versioned');
 
-    if (!fs.existsSync(eventPath)) throw new Error(`Cannot find event "${eventName}" to version`);
+      if (!fs.existsSync(eventPath)) throw new Error(`Cannot find event "${eventName}" to version`);
 
-    const { parsed: parsedEvent, raw } = readMarkdownFile(path.join(eventPath, 'index.md'));
+      const { parsed: parsedEvent, raw } = readMarkdownFile(path.join(eventPath, 'index.md'));
 
-    const { data: { version } = {} } = parsedEvent;
+      const { data: { version } = {} } = parsedEvent;
 
-    if (!version) throw new Error(`Trying to version "${eventName}" but no 'version' value found on the event`);
+      if (!version) throw new Error(`Trying to version "${eventName}" but no 'version' value found on the event`);
 
-    fs.copySync(eventPath, path.join(eventPath, '../tmp', eventName));
+      fs.copySync(eventPath, path.join(eventPath, '../tmp', eventName));
 
-    if (fs.existsSync(path.join(eventPath, '../tmp', eventName, 'versioned'))) {
-      fs.rmdirSync(path.join(eventPath, '../tmp', eventName, 'versioned'), { recursive: true });
-    }
+      if (fs.existsSync(path.join(eventPath, '../tmp', eventName, 'versioned'))) {
+        fs.rmdirSync(path.join(eventPath, '../tmp', eventName, 'versioned'), { recursive: true });
+      }
 
-    fs.moveSync(path.join(eventPath, '../tmp', eventName), path.join(versionedPath, version), {
-      overwrite: true,
-    });
+      fs.moveSync(path.join(eventPath, '../tmp', eventName), path.join(versionedPath, version), {
+        overwrite: true,
+      });
 
-    fs.rmdirSync(path.join(eventPath, '../tmp'), { recursive: true });
-
-    if (removeOnVersion) {
-      fs.copySync(path.join(eventPath, 'versioned'), path.join(eventPath, '../tmp', eventName, 'versioned'));
-      fs.rmdirSync(path.join(eventPath), { recursive: true });
-      fs.moveSync(path.join(eventPath, '../tmp', eventName, 'versioned'), path.join(eventPath, 'versioned'), { overwrite: true });
       fs.rmdirSync(path.join(eventPath, '../tmp'), { recursive: true });
-    }
 
-    return {
-      version,
-      versionedPath: path.join(versionedPath, version),
-      event: parsedEvent,
-      raw,
+      if (removeOnVersion) {
+        fs.copySync(path.join(eventPath, 'versioned'), path.join(eventPath, '../tmp', eventName, 'versioned'));
+        fs.rmdirSync(path.join(eventPath), { recursive: true });
+        fs.moveSync(path.join(eventPath, '../tmp', eventName, 'versioned'), path.join(eventPath, 'versioned'), { overwrite: true });
+        fs.rmdirSync(path.join(eventPath, '../tmp'), { recursive: true });
+      }
+
+      return {
+        version,
+        versionedPath: path.join(versionedPath, version),
+        event: parsedEvent,
+        raw,
+      };
     };
-  };
 
 export const writeEventToCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  (event: Event, options?: WriteEventToCatalogOptions): WriteEventToCatalogResponse => {
-    const { name: eventName } = event;
-    const {
-      useMarkdownContentFromExistingEvent = true,
-      renderMermaidDiagram = true,
-      renderNodeGraph = false,
-      versionExistingEvent = true,
-      schema,
-      codeExamples = [],
-      markdownContent: setMarkdownContent,
-      frontMatterToCopyToNewVersions,
-    } = options || {};
-    let markdownContent = setMarkdownContent;
+    (event: Event, options?: WriteEventToCatalogOptions): WriteEventToCatalogResponse => {
+      const { name: eventName } = event;
+      const {
+        useMarkdownContentFromExistingEvent = true,
+        renderMermaidDiagram = true,
+        renderNodeGraph = false,
+        versionExistingEvent = true,
+        schema,
+        codeExamples = [],
+        markdownContent: setMarkdownContent,
+        frontMatterToCopyToNewVersions,
+      } = options || {};
+      let markdownContent = setMarkdownContent;
 
-    if (!eventName) throw new Error('No `name` found for given event');
+      if (!eventName) throw new Error('No `name` found for given event');
 
-    const eventAlreadyInCatalog = existsInCatalog({ catalogDirectory })(eventName, { type: 'event' });
+      const eventAlreadyInCatalog = existsInCatalog({ catalogDirectory })(eventName, { type: 'event' });
 
-    if (!markdownContent && useMarkdownContentFromExistingEvent && eventAlreadyInCatalog) {
-      try {
-        const data = getEventFromCatalog({ catalogDirectory })(eventName);
-        markdownContent = data?.content ? data?.content : '';
-      } catch (error) {
-        // TODO: do nothing
-        console.log(error);
+      if (!markdownContent && useMarkdownContentFromExistingEvent && eventAlreadyInCatalog) {
+        try {
+          const data = getEventFromCatalog({ catalogDirectory })(eventName);
+          markdownContent = data?.content ? data?.content : '';
+        } catch (error) {
+          // TODO: do nothing
+          console.log(error);
+        }
       }
-    }
 
-    let defaultFrontMatterForNewEvent: any = {};
+      let defaultFrontMatterForNewEvent: any = {};
 
-    // Check if we should carry frontmatter from previous event into the new one.
-    if (eventAlreadyInCatalog && frontMatterToCopyToNewVersions) {
-      const eventFromCatalog = getEventFromCatalog({ catalogDirectory })(eventName);
-      defaultFrontMatterForNewEvent = Object.keys(frontMatterToCopyToNewVersions).reduce(
-        (defaultValues: any, key: string) =>
-          // @ts-ignore
-          frontMatterToCopyToNewVersions[key] ? { ...defaultValues, [key]: eventFromCatalog?.data[key] } : defaultValues,
-        {}
-      );
-    }
-
-    if (eventAlreadyInCatalog && versionExistingEvent) {
-      versionEvent({ catalogDirectory })(eventName);
-    }
-
-    fs.ensureDirSync(path.join(catalogDirectory, 'events', eventName));
-    const data = buildEventMarkdownForCatalog()(event, {
-      markdownContent,
-      renderMermaidDiagram,
-      renderNodeGraph,
-      includeSchemaComponent: !!schema,
-      defaultFrontMatter: defaultFrontMatterForNewEvent,
-    });
-
-    fs.writeFileSync(path.join(catalogDirectory, 'events', eventName, 'index.md'), data);
-
-    if (schema && schema.extension && schema.fileContent) {
-      fs.writeFileSync(path.join(catalogDirectory, 'events', eventName, `schema.${schema.extension}`), schema.fileContent);
-    }
-
-    if (codeExamples.length > 0) {
-      fs.ensureDirSync(path.join(catalogDirectory, 'events', eventName, 'examples'));
-      codeExamples.forEach((codeExample) => {
-        fs.writeFileSync(
-          path.join(catalogDirectory, 'events', eventName, 'examples', codeExample.fileName),
-          codeExample.fileContent
+      // Check if we should carry frontmatter from previous event into the new one.
+      if (eventAlreadyInCatalog && frontMatterToCopyToNewVersions) {
+        const eventFromCatalog = getEventFromCatalog({ catalogDirectory })(eventName);
+        defaultFrontMatterForNewEvent = Object.keys(frontMatterToCopyToNewVersions).reduce(
+          (defaultValues: any, key: string) =>
+            // @ts-ignore
+            frontMatterToCopyToNewVersions[key] ? { ...defaultValues, [key]: eventFromCatalog?.data[key] } : defaultValues,
+          {}
         );
-      });
-    }
+      }
 
-    return {
-      path: path.join(catalogDirectory, 'events', eventName),
+      if (eventAlreadyInCatalog && versionExistingEvent) {
+        versionEvent({ catalogDirectory })(eventName);
+      }
+
+      fs.ensureDirSync(path.join(catalogDirectory, 'events', eventName));
+      const data = buildEventMarkdownForCatalog()(event, {
+        markdownContent,
+        renderMermaidDiagram,
+        renderNodeGraph,
+        includeSchemaComponent: !!schema,
+        defaultFrontMatter: defaultFrontMatterForNewEvent,
+      });
+
+      fs.writeFileSync(path.join(catalogDirectory, 'events', eventName, 'index.md'), data);
+
+      if (schema && schema.extension && schema.fileContent) {
+        fs.writeFileSync(path.join(catalogDirectory, 'events', eventName, `schema.${schema.extension}`), schema.fileContent);
+      }
+
+      if (codeExamples.length > 0) {
+        fs.ensureDirSync(path.join(catalogDirectory, 'events', eventName, 'examples'));
+        codeExamples.forEach((codeExample) => {
+          fs.writeFileSync(
+            path.join(catalogDirectory, 'events', eventName, 'examples', codeExample.fileName),
+            codeExample.fileContent
+          );
+        });
+      }
+
+      return {
+        path: path.join(catalogDirectory, 'events', eventName),
+      };
     };
-  };

--- a/packages/eventcatalog-utils/src/events.ts
+++ b/packages/eventcatalog-utils/src/events.ts
@@ -26,161 +26,165 @@ const readMarkdownFile = (pathToFile: string) => {
 
 export const getEventFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-    (eventName: string) => {
-      if (!existsInCatalog({ catalogDirectory })(eventName, { type: 'event' })) {
-        return null;
-      }
+  (eventName: string) => {
+    if (!existsInCatalog({ catalogDirectory })(eventName, { type: 'event' })) {
+      return null;
+    }
 
-      // Read the directory to get the stuff we need.
-      const { parsed: parsedEvent, raw } = readMarkdownFile(path.join(catalogDirectory, 'events', eventName, 'index.md'));
+    // Read the directory to get the stuff we need.
+    const { parsed: parsedEvent, raw } = readMarkdownFile(path.join(catalogDirectory, 'events', eventName, 'index.md'));
 
-      return {
-        data: parseEventFrontMatterIntoEvent(parsedEvent.data),
-        content: parsedEvent.content,
-        raw,
-      };
+    return {
+      data: parseEventFrontMatterIntoEvent(parsedEvent.data),
+      content: parsedEvent.content,
+      raw,
     };
+  };
 
 export const getAllEventsFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-    () => {
-      const eventsDir = path.join(catalogDirectory, 'events');
-      const folders = fs.readdirSync(eventsDir);
-      const events = folders.filter((folder) => { return fs.lstatSync(folder).isDirectory() }).map((folder) => getEventFromCatalog({ catalogDirectory })(folder));
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      return events.filter((event) => event !== null).map(({ raw, ...event }: any) => event);
-    };
+  () => {
+    const eventsDir = path.join(catalogDirectory, 'events');
+    const folders = fs.readdirSync(eventsDir);
+    const events = folders
+      .filter((folder) => {
+        return fs.lstatSync(path.join(eventsDir, folder)).isDirectory();
+      })
+      .map((folder) => getEventFromCatalog({ catalogDirectory })(folder));
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    return events.filter((event) => event !== null).map(({ raw, ...event }: any) => event);
+  };
 
 export const buildEventMarkdownForCatalog =
   () =>
-    (
-      event: Event,
-      { markdownContent, includeSchemaComponent, renderMermaidDiagram, renderNodeGraph, defaultFrontMatter = {} }: any = {}
-    ) => {
-      const frontMatter = merge(event, defaultFrontMatter);
-      return buildMarkdownFile({
-        frontMatterObject: frontMatter,
-        customContent: markdownContent,
-        includeSchemaComponent,
-        renderMermaidDiagram,
-        renderNodeGraph,
-      });
-    };
+  (
+    event: Event,
+    { markdownContent, includeSchemaComponent, renderMermaidDiagram, renderNodeGraph, defaultFrontMatter = {} }: any = {}
+  ) => {
+    const frontMatter = merge(event, defaultFrontMatter);
+    return buildMarkdownFile({
+      frontMatterObject: frontMatter,
+      customContent: markdownContent,
+      includeSchemaComponent,
+      renderMermaidDiagram,
+      renderNodeGraph,
+    });
+  };
 
 export const versionEvent =
   ({ catalogDirectory }: FunctionInitInterface) =>
-    (eventName: string, { removeOnVersion = true } = {}) => {
-      const eventPath = path.join(catalogDirectory, 'events', eventName);
-      const versionedPath = path.join(catalogDirectory, 'events', eventName, 'versioned');
+  (eventName: string, { removeOnVersion = true } = {}) => {
+    const eventPath = path.join(catalogDirectory, 'events', eventName);
+    const versionedPath = path.join(catalogDirectory, 'events', eventName, 'versioned');
 
-      if (!fs.existsSync(eventPath)) throw new Error(`Cannot find event "${eventName}" to version`);
+    if (!fs.existsSync(eventPath)) throw new Error(`Cannot find event "${eventName}" to version`);
 
-      const { parsed: parsedEvent, raw } = readMarkdownFile(path.join(eventPath, 'index.md'));
+    const { parsed: parsedEvent, raw } = readMarkdownFile(path.join(eventPath, 'index.md'));
 
-      const { data: { version } = {} } = parsedEvent;
+    const { data: { version } = {} } = parsedEvent;
 
-      if (!version) throw new Error(`Trying to version "${eventName}" but no 'version' value found on the event`);
+    if (!version) throw new Error(`Trying to version "${eventName}" but no 'version' value found on the event`);
 
-      fs.copySync(eventPath, path.join(eventPath, '../tmp', eventName));
+    fs.copySync(eventPath, path.join(eventPath, '../tmp', eventName));
 
-      if (fs.existsSync(path.join(eventPath, '../tmp', eventName, 'versioned'))) {
-        fs.rmdirSync(path.join(eventPath, '../tmp', eventName, 'versioned'), { recursive: true });
-      }
+    if (fs.existsSync(path.join(eventPath, '../tmp', eventName, 'versioned'))) {
+      fs.rmdirSync(path.join(eventPath, '../tmp', eventName, 'versioned'), { recursive: true });
+    }
 
-      fs.moveSync(path.join(eventPath, '../tmp', eventName), path.join(versionedPath, version), {
-        overwrite: true,
-      });
+    fs.moveSync(path.join(eventPath, '../tmp', eventName), path.join(versionedPath, version), {
+      overwrite: true,
+    });
 
+    fs.rmdirSync(path.join(eventPath, '../tmp'), { recursive: true });
+
+    if (removeOnVersion) {
+      fs.copySync(path.join(eventPath, 'versioned'), path.join(eventPath, '../tmp', eventName, 'versioned'));
+      fs.rmdirSync(path.join(eventPath), { recursive: true });
+      fs.moveSync(path.join(eventPath, '../tmp', eventName, 'versioned'), path.join(eventPath, 'versioned'), { overwrite: true });
       fs.rmdirSync(path.join(eventPath, '../tmp'), { recursive: true });
+    }
 
-      if (removeOnVersion) {
-        fs.copySync(path.join(eventPath, 'versioned'), path.join(eventPath, '../tmp', eventName, 'versioned'));
-        fs.rmdirSync(path.join(eventPath), { recursive: true });
-        fs.moveSync(path.join(eventPath, '../tmp', eventName, 'versioned'), path.join(eventPath, 'versioned'), { overwrite: true });
-        fs.rmdirSync(path.join(eventPath, '../tmp'), { recursive: true });
-      }
-
-      return {
-        version,
-        versionedPath: path.join(versionedPath, version),
-        event: parsedEvent,
-        raw,
-      };
+    return {
+      version,
+      versionedPath: path.join(versionedPath, version),
+      event: parsedEvent,
+      raw,
     };
+  };
 
 export const writeEventToCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-    (event: Event, options?: WriteEventToCatalogOptions): WriteEventToCatalogResponse => {
-      const { name: eventName } = event;
-      const {
-        useMarkdownContentFromExistingEvent = true,
-        renderMermaidDiagram = true,
-        renderNodeGraph = false,
-        versionExistingEvent = true,
-        schema,
-        codeExamples = [],
-        markdownContent: setMarkdownContent,
-        frontMatterToCopyToNewVersions,
-      } = options || {};
-      let markdownContent = setMarkdownContent;
+  (event: Event, options?: WriteEventToCatalogOptions): WriteEventToCatalogResponse => {
+    const { name: eventName } = event;
+    const {
+      useMarkdownContentFromExistingEvent = true,
+      renderMermaidDiagram = true,
+      renderNodeGraph = false,
+      versionExistingEvent = true,
+      schema,
+      codeExamples = [],
+      markdownContent: setMarkdownContent,
+      frontMatterToCopyToNewVersions,
+    } = options || {};
+    let markdownContent = setMarkdownContent;
 
-      if (!eventName) throw new Error('No `name` found for given event');
+    if (!eventName) throw new Error('No `name` found for given event');
 
-      const eventAlreadyInCatalog = existsInCatalog({ catalogDirectory })(eventName, { type: 'event' });
+    const eventAlreadyInCatalog = existsInCatalog({ catalogDirectory })(eventName, { type: 'event' });
 
-      if (!markdownContent && useMarkdownContentFromExistingEvent && eventAlreadyInCatalog) {
-        try {
-          const data = getEventFromCatalog({ catalogDirectory })(eventName);
-          markdownContent = data?.content ? data?.content : '';
-        } catch (error) {
-          // TODO: do nothing
-          console.log(error);
-        }
+    if (!markdownContent && useMarkdownContentFromExistingEvent && eventAlreadyInCatalog) {
+      try {
+        const data = getEventFromCatalog({ catalogDirectory })(eventName);
+        markdownContent = data?.content ? data?.content : '';
+      } catch (error) {
+        // TODO: do nothing
+        console.log(error);
       }
+    }
 
-      let defaultFrontMatterForNewEvent: any = {};
+    let defaultFrontMatterForNewEvent: any = {};
 
-      // Check if we should carry frontmatter from previous event into the new one.
-      if (eventAlreadyInCatalog && frontMatterToCopyToNewVersions) {
-        const eventFromCatalog = getEventFromCatalog({ catalogDirectory })(eventName);
-        defaultFrontMatterForNewEvent = Object.keys(frontMatterToCopyToNewVersions).reduce(
-          (defaultValues: any, key: string) =>
-            // @ts-ignore
-            frontMatterToCopyToNewVersions[key] ? { ...defaultValues, [key]: eventFromCatalog?.data[key] } : defaultValues,
-          {}
+    // Check if we should carry frontmatter from previous event into the new one.
+    if (eventAlreadyInCatalog && frontMatterToCopyToNewVersions) {
+      const eventFromCatalog = getEventFromCatalog({ catalogDirectory })(eventName);
+      defaultFrontMatterForNewEvent = Object.keys(frontMatterToCopyToNewVersions).reduce(
+        (defaultValues: any, key: string) =>
+          // @ts-ignore
+          frontMatterToCopyToNewVersions[key] ? { ...defaultValues, [key]: eventFromCatalog?.data[key] } : defaultValues,
+        {}
+      );
+    }
+
+    if (eventAlreadyInCatalog && versionExistingEvent) {
+      versionEvent({ catalogDirectory })(eventName);
+    }
+
+    fs.ensureDirSync(path.join(catalogDirectory, 'events', eventName));
+    const data = buildEventMarkdownForCatalog()(event, {
+      markdownContent,
+      renderMermaidDiagram,
+      renderNodeGraph,
+      includeSchemaComponent: !!schema,
+      defaultFrontMatter: defaultFrontMatterForNewEvent,
+    });
+
+    fs.writeFileSync(path.join(catalogDirectory, 'events', eventName, 'index.md'), data);
+
+    if (schema && schema.extension && schema.fileContent) {
+      fs.writeFileSync(path.join(catalogDirectory, 'events', eventName, `schema.${schema.extension}`), schema.fileContent);
+    }
+
+    if (codeExamples.length > 0) {
+      fs.ensureDirSync(path.join(catalogDirectory, 'events', eventName, 'examples'));
+      codeExamples.forEach((codeExample) => {
+        fs.writeFileSync(
+          path.join(catalogDirectory, 'events', eventName, 'examples', codeExample.fileName),
+          codeExample.fileContent
         );
-      }
-
-      if (eventAlreadyInCatalog && versionExistingEvent) {
-        versionEvent({ catalogDirectory })(eventName);
-      }
-
-      fs.ensureDirSync(path.join(catalogDirectory, 'events', eventName));
-      const data = buildEventMarkdownForCatalog()(event, {
-        markdownContent,
-        renderMermaidDiagram,
-        renderNodeGraph,
-        includeSchemaComponent: !!schema,
-        defaultFrontMatter: defaultFrontMatterForNewEvent,
       });
+    }
 
-      fs.writeFileSync(path.join(catalogDirectory, 'events', eventName, 'index.md'), data);
-
-      if (schema && schema.extension && schema.fileContent) {
-        fs.writeFileSync(path.join(catalogDirectory, 'events', eventName, `schema.${schema.extension}`), schema.fileContent);
-      }
-
-      if (codeExamples.length > 0) {
-        fs.ensureDirSync(path.join(catalogDirectory, 'events', eventName, 'examples'));
-        codeExamples.forEach((codeExample) => {
-          fs.writeFileSync(
-            path.join(catalogDirectory, 'events', eventName, 'examples', codeExample.fileName),
-            codeExample.fileContent
-          );
-        });
-      }
-
-      return {
-        path: path.join(catalogDirectory, 'events', eventName),
-      };
+    return {
+      path: path.join(catalogDirectory, 'events', eventName),
     };
+  };

--- a/packages/eventcatalog-utils/src/services.ts
+++ b/packages/eventcatalog-utils/src/services.ts
@@ -18,67 +18,67 @@ const readMarkdownFile = (pathToFile: string) => {
 
 export const buildServiceMarkdownForCatalog =
   () =>
-  (service: Service, { markdownContent, renderMermaidDiagram = true, renderNodeGraph = false }: any = {}) =>
-    buildMarkdownFile({
-      frontMatterObject: service,
-      customContent: markdownContent,
-      renderMermaidDiagram,
-      renderNodeGraph,
-    });
+    (service: Service, { markdownContent, renderMermaidDiagram = true, renderNodeGraph = false }: any = {}) =>
+      buildMarkdownFile({
+        frontMatterObject: service,
+        customContent: markdownContent,
+        renderMermaidDiagram,
+        renderNodeGraph,
+      });
 
 export const getAllServicesFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  (): any[] => {
-    const servicesDir = path.join(catalogDirectory, 'services');
-    const folders = fs.readdirSync(servicesDir);
-    return folders.map((folder) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { raw, ...service }: any = getServiceFromCatalog({ catalogDirectory })(folder);
-      return service;
-    });
-  };
+    (): any[] => {
+      const servicesDir = path.join(catalogDirectory, 'services');
+      const folders = fs.readdirSync(servicesDir);
+      return folders.filter((folder) => { return fs.lstatSync(folder).isDirectory() }).map((folder) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { raw, ...service }: any = getServiceFromCatalog({ catalogDirectory })(folder);
+        return service;
+      });
+    };
 
 export const getServiceFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  (seriveName: string) => {
-    try {
-      // Read the directory to get the stuff we need.
-      const { parsed: parsedService, raw } = readMarkdownFile(path.join(catalogDirectory, 'services', seriveName, 'index.md'));
-      return {
-        data: parsedService.data,
-        content: parsedService.content,
-        raw,
-      };
-    } catch (error) {
-      return null;
-    }
-  };
+    (seriveName: string) => {
+      try {
+        // Read the directory to get the stuff we need.
+        const { parsed: parsedService, raw } = readMarkdownFile(path.join(catalogDirectory, 'services', seriveName, 'index.md'));
+        return {
+          data: parsedService.data,
+          content: parsedService.content,
+          raw,
+        };
+      } catch (error) {
+        return null;
+      }
+    };
 
 export const writeServiceToCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  (service: Service, options?: WriteServiceToCatalogInterface): WriteServiceToCatalogInterfaceReponse => {
-    const { name: serviceName } = service;
-    const { useMarkdownContentFromExistingService = true, renderMermaidDiagram = true, renderNodeGraph = false } = options || {};
-    let markdownContent;
+    (service: Service, options?: WriteServiceToCatalogInterface): WriteServiceToCatalogInterfaceReponse => {
+      const { name: serviceName } = service;
+      const { useMarkdownContentFromExistingService = true, renderMermaidDiagram = true, renderNodeGraph = false } = options || {};
+      let markdownContent;
 
-    if (!serviceName) throw new Error('No `name` found for given service');
+      if (!serviceName) throw new Error('No `name` found for given service');
 
-    if (useMarkdownContentFromExistingService) {
-      const data = getServiceFromCatalog({ catalogDirectory })(serviceName);
-      markdownContent = data?.content ? data?.content : '';
-    }
+      if (useMarkdownContentFromExistingService) {
+        const data = getServiceFromCatalog({ catalogDirectory })(serviceName);
+        markdownContent = data?.content ? data?.content : '';
+      }
 
-    const data = buildServiceMarkdownForCatalog()(service, {
-      markdownContent,
-      useMarkdownContentFromExistingService,
-      renderMermaidDiagram,
-      renderNodeGraph,
-    });
+      const data = buildServiceMarkdownForCatalog()(service, {
+        markdownContent,
+        useMarkdownContentFromExistingService,
+        renderMermaidDiagram,
+        renderNodeGraph,
+      });
 
-    fs.ensureDirSync(path.join(catalogDirectory, 'services', service.name));
-    fs.writeFileSync(path.join(catalogDirectory, 'services', service.name, 'index.md'), data);
+      fs.ensureDirSync(path.join(catalogDirectory, 'services', service.name));
+      fs.writeFileSync(path.join(catalogDirectory, 'services', service.name, 'index.md'), data);
 
-    return {
-      path: path.join(catalogDirectory, 'services', service.name),
+      return {
+        path: path.join(catalogDirectory, 'services', service.name),
+      };
     };
-  };

--- a/packages/eventcatalog-utils/src/services.ts
+++ b/packages/eventcatalog-utils/src/services.ts
@@ -18,67 +18,71 @@ const readMarkdownFile = (pathToFile: string) => {
 
 export const buildServiceMarkdownForCatalog =
   () =>
-    (service: Service, { markdownContent, renderMermaidDiagram = true, renderNodeGraph = false }: any = {}) =>
-      buildMarkdownFile({
-        frontMatterObject: service,
-        customContent: markdownContent,
-        renderMermaidDiagram,
-        renderNodeGraph,
-      });
+  (service: Service, { markdownContent, renderMermaidDiagram = true, renderNodeGraph = false }: any = {}) =>
+    buildMarkdownFile({
+      frontMatterObject: service,
+      customContent: markdownContent,
+      renderMermaidDiagram,
+      renderNodeGraph,
+    });
 
 export const getAllServicesFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-    (): any[] => {
-      const servicesDir = path.join(catalogDirectory, 'services');
-      const folders = fs.readdirSync(servicesDir);
-      return folders.filter((folder) => { return fs.lstatSync(folder).isDirectory() }).map((folder) => {
+  (): any[] => {
+    const servicesDir = path.join(catalogDirectory, 'services');
+    const folders = fs.readdirSync(servicesDir);
+    return folders
+      .filter((folder) => {
+        return fs.lstatSync(path.join(servicesDir, folder)).isDirectory();
+      })
+      .map((folder) => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { raw, ...service }: any = getServiceFromCatalog({ catalogDirectory })(folder);
         return service;
       });
-    };
+  };
 
 export const getServiceFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-    (seriveName: string) => {
-      try {
-        // Read the directory to get the stuff we need.
-        const { parsed: parsedService, raw } = readMarkdownFile(path.join(catalogDirectory, 'services', seriveName, 'index.md'));
-        return {
-          data: parsedService.data,
-          content: parsedService.content,
-          raw,
-        };
-      } catch (error) {
-        return null;
-      }
-    };
+  (seriveName: string) => {
+    try {
+      // Read the directory to get the stuff we need.
+      const { parsed: parsedService, raw } = readMarkdownFile(path.join(catalogDirectory, 'services', seriveName, 'index.md'));
+      return {
+        data: parsedService.data,
+        content: parsedService.content,
+        raw,
+      };
+    } catch (error) {
+      return null;
+    }
+  };
 
 export const writeServiceToCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-    (service: Service, options?: WriteServiceToCatalogInterface): WriteServiceToCatalogInterfaceReponse => {
-      const { name: serviceName } = service;
-      const { useMarkdownContentFromExistingService = true, renderMermaidDiagram = true, renderNodeGraph = false } = options || {};
-      let markdownContent;
+  (service: Service, options?: WriteServiceToCatalogInterface): WriteServiceToCatalogInterfaceReponse => {
+    const { name: serviceName } = service;
+    const { useMarkdownContentFromExistingService = true, renderMermaidDiagram = true, renderNodeGraph = false } = options || {};
+    let markdownContent;
 
-      if (!serviceName) throw new Error('No `name` found for given service');
+    if (!serviceName) throw new Error('No `name` found for given service');
 
-      if (useMarkdownContentFromExistingService) {
-        const data = getServiceFromCatalog({ catalogDirectory })(serviceName);
-        markdownContent = data?.content ? data?.content : '';
-      }
+    if (useMarkdownContentFromExistingService) {
+      const data = getServiceFromCatalog({ catalogDirectory })(serviceName);
+      markdownContent = data?.content ? data?.content : '';
+    }
 
-      const data = buildServiceMarkdownForCatalog()(service, {
-        markdownContent,
-        useMarkdownContentFromExistingService,
-        renderMermaidDiagram,
-        renderNodeGraph,
-      });
+    const data = buildServiceMarkdownForCatalog()(service, {
+      markdownContent,
+      useMarkdownContentFromExistingService,
+      renderMermaidDiagram,
+      renderNodeGraph,
+    });
 
-      fs.ensureDirSync(path.join(catalogDirectory, 'services', service.name));
-      fs.writeFileSync(path.join(catalogDirectory, 'services', service.name, 'index.md'), data);
+    fs.ensureDirSync(path.join(catalogDirectory, 'services', service.name));
+    fs.writeFileSync(path.join(catalogDirectory, 'services', service.name, 'index.md'), data);
 
-      return {
-        path: path.join(catalogDirectory, 'services', service.name),
-      };
+    return {
+      path: path.join(catalogDirectory, 'services', service.name),
     };
+  };

--- a/packages/eventcatalog/lib/domains.ts
+++ b/packages/eventcatalog/lib/domains.ts
@@ -153,7 +153,11 @@ export const getDomainByPath = async (domainDirectory: string): Promise<{ domain
 export const getAllDomainsFromPath = async (domainsDir: string) => {
   if (!fs.existsSync(domainsDir)) return [];
   const folders = fs.readdirSync(domainsDir);
-  const allDomains = folders.filter((folder) => { return fs.lstatSync(path.join(domainsDir, folder)).isDirectory() }).map((folder) => getDomainByPath(path.join(domainsDir, folder)));
+  const allDomains = folders
+    .filter((folder) => {
+      return fs.lstatSync(path.join(domainsDir, folder)).isDirectory();
+    })
+    .map((folder) => getDomainByPath(path.join(domainsDir, folder)));
   return Promise.all(allDomains);
 };
 

--- a/packages/eventcatalog/lib/domains.ts
+++ b/packages/eventcatalog/lib/domains.ts
@@ -153,7 +153,7 @@ export const getDomainByPath = async (domainDirectory: string): Promise<{ domain
 export const getAllDomainsFromPath = async (domainsDir: string) => {
   if (!fs.existsSync(domainsDir)) return [];
   const folders = fs.readdirSync(domainsDir);
-  const allDomains = folders.map((folder) => getDomainByPath(path.join(domainsDir, folder)));
+  const allDomains = folders.filter((folder) => { return fs.lstatSync(path.join(domainsDir, folder)).isDirectory() }).map((folder) => getDomainByPath(path.join(domainsDir, folder)));
   return Promise.all(allDomains);
 };
 

--- a/packages/eventcatalog/lib/events.ts
+++ b/packages/eventcatalog/lib/events.ts
@@ -84,11 +84,11 @@ export const getLogsForEvent = ({ eventName, domain }: { eventName: string; doma
         value:
           schema && previousSchema
             ? Diff.createTwoFilesPatch(
-                `schema.${schema.extension} (${previousVersion})`,
-                `schema.${previousSchema.extension} (${version})`,
-                previousSchema.snippet,
-                schema.snippet
-              )
+              `schema.${schema.extension} (${previousVersion})`,
+              `schema.${previousSchema.extension} (${version})`,
+              previousSchema.snippet,
+              schema.snippet
+            )
             : null,
       };
 
@@ -168,7 +168,7 @@ export const getEventByPath = (eventDir: string, hydrateWithProducersAndConsumer
 export const getAllEventsFromPath = (eventsDir: string, hydrateEvents?: boolean): Event[] => {
   if (!fs.existsSync(eventsDir)) return [];
   const folders = fs.readdirSync(eventsDir);
-  return folders.map((folder) => getEventByPath(path.join(eventsDir, folder), hydrateEvents));
+  return folders.filter((folder) => { return fs.lstatSync(path.join(eventsDir, folder)).isDirectory() }).map((folder) => getEventByPath(path.join(eventsDir, folder), hydrateEvents));
 };
 
 export const getAllEvents = ({ hydrateEvents }: { hydrateEvents?: boolean } = {}): Event[] => {

--- a/packages/eventcatalog/lib/events.ts
+++ b/packages/eventcatalog/lib/events.ts
@@ -84,11 +84,11 @@ export const getLogsForEvent = ({ eventName, domain }: { eventName: string; doma
         value:
           schema && previousSchema
             ? Diff.createTwoFilesPatch(
-              `schema.${schema.extension} (${previousVersion})`,
-              `schema.${previousSchema.extension} (${version})`,
-              previousSchema.snippet,
-              schema.snippet
-            )
+                `schema.${schema.extension} (${previousVersion})`,
+                `schema.${previousSchema.extension} (${version})`,
+                previousSchema.snippet,
+                schema.snippet
+              )
             : null,
       };
 
@@ -168,7 +168,11 @@ export const getEventByPath = (eventDir: string, hydrateWithProducersAndConsumer
 export const getAllEventsFromPath = (eventsDir: string, hydrateEvents?: boolean): Event[] => {
   if (!fs.existsSync(eventsDir)) return [];
   const folders = fs.readdirSync(eventsDir);
-  return folders.filter((folder) => { return fs.lstatSync(path.join(eventsDir, folder)).isDirectory() }).map((folder) => getEventByPath(path.join(eventsDir, folder), hydrateEvents));
+  return folders
+    .filter((folder) => {
+      return fs.lstatSync(path.join(eventsDir, folder)).isDirectory();
+    })
+    .map((folder) => getEventByPath(path.join(eventsDir, folder), hydrateEvents));
 };
 
 export const getAllEvents = ({ hydrateEvents }: { hydrateEvents?: boolean } = {}): Event[] => {

--- a/packages/eventcatalog/lib/services.ts
+++ b/packages/eventcatalog/lib/services.ts
@@ -31,7 +31,11 @@ export const getAllServicesFromPath = (serviceDir: string): Service[] => {
   if (!fs.existsSync(serviceDir)) return [];
   const folders = fs.readdirSync(serviceDir);
   const events = getAllEvents();
-  const services = folders.filter((folder) => { return fs.lstatSync(folder).isDirectory() }).map((folder) => getServiceByPath(path.join(serviceDir, folder)));
+  const services = folders
+    .filter((folder) => {
+      return fs.lstatSync(path.join(serviceDir, folder)).isDirectory();
+    })
+    .map((folder) => getServiceByPath(path.join(serviceDir, folder)));
 
   // // @ts-ignore
   return services.map((service) => ({

--- a/packages/eventcatalog/lib/services.ts
+++ b/packages/eventcatalog/lib/services.ts
@@ -31,7 +31,7 @@ export const getAllServicesFromPath = (serviceDir: string): Service[] => {
   if (!fs.existsSync(serviceDir)) return [];
   const folders = fs.readdirSync(serviceDir);
   const events = getAllEvents();
-  const services = folders.map((folder) => getServiceByPath(path.join(serviceDir, folder)));
+  const services = folders.filter((folder) => { return fs.lstatSync(folder).isDirectory() }).map((folder) => getServiceByPath(path.join(serviceDir, folder)));
 
   // // @ts-ignore
   return services.map((service) => ({

--- a/packages/eventcatalog/scripts/move-schemas-for-download.js
+++ b/packages/eventcatalog/scripts/move-schemas-for-download.js
@@ -3,7 +3,9 @@ const fs = require('fs');
 
 const getAllEventsAndSchemaPaths = (directory) => {
   const folders = fs.readdirSync(directory);
-  return folders.map((folder) => {
+  return folders
+    .filter((folder) => { return fs.lstatSync(path.join(directory, folder)).isDirectory() })
+    .map((folder) => {
     const allFilesInEventFolder = fs.readdirSync(path.join(directory, folder));
     const schemaFileName = allFilesInEventFolder.find((fileName) => fileName.includes('schema'));
     const eventHasVersions = !!allFilesInEventFolder.find((fileName) => fileName.includes('versioned'));

--- a/packages/eventcatalog/scripts/move-schemas-for-download.js
+++ b/packages/eventcatalog/scripts/move-schemas-for-download.js
@@ -4,24 +4,26 @@ const fs = require('fs');
 const getAllEventsAndSchemaPaths = (directory) => {
   const folders = fs.readdirSync(directory);
   return folders
-    .filter((folder) => { return fs.lstatSync(path.join(directory, folder)).isDirectory() })
+    .filter((folder) => {
+      return fs.lstatSync(path.join(directory, folder)).isDirectory();
+    })
     .map((folder) => {
-    const allFilesInEventFolder = fs.readdirSync(path.join(directory, folder));
-    const schemaFileName = allFilesInEventFolder.find((fileName) => fileName.includes('schema'));
-    const eventHasVersions = !!allFilesInEventFolder.find((fileName) => fileName.includes('versioned'));
-    let versions = [];
+      const allFilesInEventFolder = fs.readdirSync(path.join(directory, folder));
+      const schemaFileName = allFilesInEventFolder.find((fileName) => fileName.includes('schema'));
+      const eventHasVersions = !!allFilesInEventFolder.find((fileName) => fileName.includes('versioned'));
+      let versions = [];
 
-    if (eventHasVersions) {
-      versions = getAllEventsAndSchemaPaths(path.join(directory, folder, 'versioned'));
-    }
+      if (eventHasVersions) {
+        versions = getAllEventsAndSchemaPaths(path.join(directory, folder, 'versioned'));
+      }
 
-    return {
-      name: folder,
-      schemaFileName,
-      schemaContent: schemaFileName ? fs.readFileSync(path.join(directory, folder, schemaFileName), 'utf-8') : null,
-      versions,
-    };
-  });
+      return {
+        name: folder,
+        schemaFileName,
+        schemaContent: schemaFileName ? fs.readFileSync(path.join(directory, folder, schemaFileName), 'utf-8') : null,
+        versions,
+      };
+    });
 };
 
 const parseEventDirectory = (publicSchemaDir, eventsDir) => {


### PR DESCRIPTION
## Motivation

In the project I'm currently work on, I am writing code and doing documentation at same time (it's just me ¯\\\_(ツ)\_/¯), and I made a script with `cookiecutter` to create automaticaly source code **AND** documentation folders/files inside EventCatalog.

But today I encountered an error and when I lookup was because in the `packages/eventcatalog/scripts/move-schemas-for-download.js` the script was trying to read my .`gitkeep` file. _(That is because my pre-commit in this project have another script to add/remove `.gitkeep` on folders - depending if they are empty or not)_.

So I take this opportunity to help in some way to this great project! When the code is expecting to read a folder, I put a filter to return only folders. This could solve the error I encountered and let others users to save files in this folders (since I think this is not a problem, but I could be wrong here).

That's it! If y'all think this is not necessary, it's ok!

Thanks!

<img src="https://media1.giphy.com/media/PSKAppO2LH56w/giphy.gif"/>

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes!
