### PR TITLE
fix: support spaces in projectDIR path

### DIFF
--- a/.changeset/short-items-walk.md
+++ b/.changeset/short-items-walk.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: support spaces in projectDIR path

--- a/packages/eventcatalog/bin/eventcatalog.js
+++ b/packages/eventcatalog/bin/eventcatalog.js
@@ -33,7 +33,7 @@ cli
   .command('start [siteDir]')
   .description('Start the development server.')
   .action(() => {
-    execSync(`cross-env PROJECT_DIR=${projectDIR} npm run start`, {
+    execSync(`cross-env PROJECT_DIR='${projectDIR}' npm run start`, {
       cwd: eventCatalogLibDir,
       stdio: 'inherit',
     });
@@ -51,13 +51,13 @@ cli
     fs.copySync(path.join(projectDIR, 'public'), path.join(eventCatalogLibDir, 'public'));
 
     // Move the schemas into public directory so we can download them from UI
-    execSync(`cross-env PROJECT_DIR=${projectDIR} npm run scripts:move-schema-for-download`, {
+    execSync(`cross-env PROJECT_DIR='${projectDIR}' npm run scripts:move-schema-for-download`, {
       cwd: eventCatalogLibDir,
       stdio: 'inherit',
     });
 
     // build using nextjs
-    execSync(`cross-env PROJECT_DIR=${projectDIR} npm run build`, {
+    execSync(`cross-env PROJECT_DIR='${projectDIR}' npm run build`, {
       cwd: eventCatalogLibDir,
       stdio: 'inherit',
     });
@@ -82,12 +82,12 @@ cli
     fs.copyFileSync(path.join(projectDIR, 'eventcatalog.config.js'), path.join(eventCatalogLibDir, 'eventcatalog.config.js'));
 
     // Move the schemas into public directory so we can download them from UI
-    execSync(`cross-env PROJECT_DIR=${projectDIR} npm run scripts:move-schema-for-download`, {
+    execSync(`cross-env PROJECT_DIR='${projectDIR}' npm run scripts:move-schema-for-download`, {
       cwd: eventCatalogLibDir,
       stdio: 'inherit',
     });
 
-    execSync(`cross-env PROJECT_DIR=${projectDIR} npm run dev`, {
+    execSync(`cross-env PROJECT_DIR='${projectDIR}' npm run dev`, {
       cwd: eventCatalogLibDir,
       stdio: 'inherit',
     });
@@ -105,7 +105,7 @@ cli
 
     fs.copyFileSync(path.join(projectDIR, 'eventcatalog.config.js'), path.join(eventCatalogLibDir, 'eventcatalog.config.js'));
 
-    execSync(`cross-env PROJECT_DIR=${projectDIR} npm run generate`, {
+    execSync(`cross-env PROJECT_DIR='${projectDIR}' npm run generate`, {
       cwd: eventCatalogLibDir,
       stdio: 'inherit',
     });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Wanted to check this out and was following the installation guide here https://www.eventcatalog.dev/docs/installation#running-the-development-server. When I tried to `npm run dev`, it failed because there were spaces in my projectDIR path.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
