### PR TITLE
fix 3d node graph

### DIFF
--- a/.changeset/green-cheetahs-develop.md
+++ b/.changeset/green-cheetahs-develop.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+Fix to the 3D node graph

--- a/packages/eventcatalog/pages/_document.tsx
+++ b/packages/eventcatalog/pages/_document.tsx
@@ -5,7 +5,7 @@ export default function Document() {
     <Html>
       <Head>
         <script src="//unpkg.com/three@0.145.0/build/three.min.js" />
-        <script src="//unpkg.com/three/examples/js/renderers/CSS2DRenderer.js" />
+        <script src="//unpkg.com/three@0.145.0/examples/js/renderers/CSS2DRenderer.js" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/atom-one-light.min.css" />
       </Head>


### PR DESCRIPTION
Fix #329

## Motivation
https://app.eventcatalog.dev/overview/ was broken. This should fix it.

Since three@0.145.0 was used directly in _document.tsx, I aligned the use of three@0.145.0/examples/js/renderers/CSS2DRenderer.js.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?
Yes