### PR TITLE
fix: correct display of users in domain

### DIFF
--- a/.changeset/lucky-insects-arrive.md
+++ b/.changeset/lucky-insects-arrive.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/core': patch
+---
+
+fix to correctly display the user when there are no events associated with a domain.

--- a/.changeset/rude-pears-occur.md
+++ b/.changeset/rude-pears-occur.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix: correct display of users in domain

--- a/packages/eventcatalog/lib/events.ts
+++ b/packages/eventcatalog/lib/events.ts
@@ -6,7 +6,7 @@ import { serialize } from 'next-mdx-remote/serialize';
 import path from 'path';
 import { MarkdownFile } from '@/types/index';
 import { getLastModifiedDateOfFile, getSchemaFromDir, readMarkdownFile } from '@/lib/file-reader';
-import { getAllEventsFromDomains } from './domains';
+import { getAllDomains, getAllEventsFromDomains } from './domains';
 import { extentionToLanguageMap } from './file-reader';
 import { getAllServices, hydrateEventProducersAndConsumers } from './services';
 
@@ -181,12 +181,14 @@ export const getAllEvents = ({ hydrateEvents }: { hydrateEvents?: boolean } = {}
   return sortedEvents;
 };
 
-export const getAllOwners = (): string[] => {
+export const getAllOwners = async (): Promise<string[]> => {
+  const allDomains = await getAllDomains();
   const allEvents = getAllEvents();
   const allServices = getAllServices();
+  const allOwnersInDomains = allDomains.reduce((owners, file) => owners.concat(file.domain.owners), []);
   const allOwnersInEvents = allEvents.reduce((owners, event) => owners.concat(event.owners), []);
   const allOwnersInServices = allServices.reduce((owners, service) => owners.concat(service.owners), []);
-  const allOwnersDocumented = allOwnersInEvents.concat(allOwnersInServices);
+  const allOwnersDocumented = [].concat(allOwnersInDomains, allOwnersInEvents, allOwnersInServices);
   // @ts-ignore
   return [...new Set(allOwnersDocumented)];
 };

--- a/packages/eventcatalog/pages/users/[id].tsx
+++ b/packages/eventcatalog/pages/users/[id].tsx
@@ -32,18 +32,24 @@ export default function UserPage({ events, services, domains, userId }: UserPage
                   <h1 className="text-3xl font-bold text-gray-900 relative">{user.name}</h1>
                 </div>
               </div>
-              <div className="border-b border-gray-100 pb-6">
-                <h1 className="text-lg font-bold text-gray-800 relative mt-4">Owner of Events ({events.length})</h1>
-                <EventGrid events={events} />
-              </div>
-              <div className="border-b border-gray-100 pb-6">
-                <h1 className="text-lg font-bold text-gray-800 relative mt-4 ">Owner of Services ({services.length})</h1>
-                <ServiceGrid services={services} />
-              </div>
-              <div>
-                <h1 className="text-lg font-bold text-gray-800 relative mt-4">Owner of Domains ({domains.length})</h1>
-                <DomainGrid domains={domains} />
-              </div>
+              {events.length > 0 && (
+                <div className="border-b border-gray-100 pb-6">
+                  <h1 className="text-lg font-bold text-gray-800 relative mt-4">Owner of Events ({events.length})</h1>
+                  <EventGrid events={events} />
+                </div>
+              )}
+              {services.length > 0 && (
+                <div className="border-b border-gray-100 pb-6">
+                  <h1 className="text-lg font-bold text-gray-800 relative mt-4 ">Owner of Services ({services.length})</h1>
+                  <ServiceGrid services={services} />
+                </div>
+              )}
+              {domains.length > 0 && (
+                <div>
+                  <h1 className="text-lg font-bold text-gray-800 relative mt-4">Owner of Domains ({domains.length})</h1>
+                  <DomainGrid domains={domains} />
+                </div>
+              )}
             </div>
             <div className="px-8">
               <div className="flex items-center space-x-5 mt-4 ">
@@ -84,7 +90,7 @@ export const getStaticProps = async ({ params }) => {
 };
 
 export async function getStaticPaths() {
-  const owners = getAllOwners();
+  const owners = await getAllOwners();
 
   const paths = owners.map((owner) => ({ params: { id: owner } }));
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The following PR solves these two problems:
1. when I create a domain without events and add a domain owner, when clicked it does not display returning 404 not found.
2. The user page only returns the information (domains, events and services) that counts available.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

yes
