### PR TITLE
fix(schemas): Dont fail for schemas in custom registries

### DIFF
--- a/.changeset/cyan-ways-kick.md
+++ b/.changeset/cyan-ways-kick.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/plugin-doc-generator-amazon-eventbridge": patch
+---
+
+fix(schemas): Dont fail for schemas in custom registries


### PR DESCRIPTION
## Motivation

Added a fix for https://github.com/boyney123/eventcatalog/issues/270 so it doesn't fail when it tries to download the schema from a custom registry.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
