### PR TITLE
docs: add types to upgrade guide

### DIFF
--- a/packages/eventcatalog/tailwind.config.js
+++ b/packages/eventcatalog/tailwind.config.js
@@ -34,5 +34,3 @@ module.exports = {
   },
   plugins: [require('@tailwindcss/typography'), require('@tailwindcss/forms'), require('@tailwindcss/line-clamp')],
 };
-
-

--- a/website/docs/guides/upgrading.md
+++ b/website/docs/guides/upgrading.md
@@ -2,9 +2,9 @@
 sidebar_position: 4
 id: upgrading
 title: Upgrade Catalog
----  
+---
 
-To upgrade your EventCatalog you can find the package `"@eventcatalog/core"` to upgrade in your `package.json` file.
+To upgrade your EventCatalog you can find the packages `"@eventcatalog/core"` and `"@eventcatalog/types"` to upgrade in your `package.json` file.
 
 ```json
 {
@@ -14,11 +14,11 @@ To upgrade your EventCatalog you can find the package `"@eventcatalog/core"` to 
   "scripts": {
     ...
   },
-  "devDependencies": {
-   ...
-  },
   "dependencies": {
-    "@eventcatalog/core": "0.0.5"
+    "@eventcatalog/core": "0.6.8"
+  },
+  "devDependencies": {
+   "@eventcatalog/types": "0.4.1",
   }
 }
 ```

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -13,9 +13,7 @@ const config = {
   favicon: 'img/favicon.ico',
   organizationName: 'facebook', // Usually your GitHub org/user name.
   projectName: 'docusaurus', // Usually your repo name.
-  plugins: [
-    'my-loaders',
-  ],
+  plugins: ['my-loaders'],
   scripts: ['https://unpkg.com/browse/leader-line@1.0.7/leader-line.min.js'],
   presets: [
     [


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

After upgrading to **@eventcatalog/core 0.6.8** (following the upgrade guide) to use event tags, our build started to fail because of an outdated **@eventcatalog/types** version. After updating the **@eventcatalog/types** to the latest version in our event catalog project, the build started to work again.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.
