### PR TITLE
fix: Resolve relative references when parsing AsyncAPI

### DIFF
--- a/.changeset/cuddly-cougars-kick.md
+++ b/.changeset/cuddly-cougars-kick.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/plugin-doc-generator-asyncapi": patch
+---
+
+resolve relative references

--- a/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
+++ b/packages/eventcatalog-plugin-generator-asyncapi/src/index.ts
@@ -88,7 +88,7 @@ const parseAsyncAPIFile = async (pathToFile: string, options: AsyncAPIPluginOpti
     throw new Error(`Failed to read file with provided path`);
   }
 
-  const doc = await parse(asyncAPIFile);
+  const doc = await parse(asyncAPIFile, { path: pathToFile });
 
   const service = getServiceFromAsyncDoc(doc);
   const events = getAllEventsFromAsyncDoc(doc, options);


### PR DESCRIPTION
Add path to ParserOptions to resolve relative paths.

## Motivation

Fixes #238.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.
