### PR TITLE
add the AsyncAPI component to the markdown and save it in the service…

### DIFF
--- a/packages/eventcatalog-utils/src/markdown-builder.ts
+++ b/packages/eventcatalog-utils/src/markdown-builder.ts
@@ -8,21 +8,24 @@ export default ({
   includeSchemaComponent = false,
   renderMermaidDiagram = false,
   renderNodeGraph = true,
+  includeAsyncApiComponent = false
 }: {
   frontMatterObject: Service | Event | Domain;
   customContent?: string;
   includeSchemaComponent?: boolean;
   renderMermaidDiagram?: boolean;
   renderNodeGraph?: boolean;
+  includeAsyncApiComponent?: boolean;
 }) => {
   const customJSON2MD = (content: any) => {
     json2md.converters.mermaid = (render) => (render ? '<Mermaid />' : '');
     json2md.converters.schema = (render) => (render ? '<Schema />' : '');
     json2md.converters.nodeGraph = (render) => (render ? '<NodeGraph />' : '');
+    json2md.converters.asyncAPI = (render) => (render ? '<AsyncAPI  />' : '');
     return json2md(content);
   };
 
-  const content = [{ mermaid: renderMermaidDiagram }, { nodeGraph: renderNodeGraph }, { schema: includeSchemaComponent }];
+  const content = [{ mermaid: renderMermaidDiagram }, { nodeGraph: renderNodeGraph }, { schema: includeSchemaComponent }, {asyncAPI: includeAsyncApiComponent}];
 
   return `---
 ${YAML.stringify(frontMatterObject)}---

--- a/packages/eventcatalog-utils/src/services.ts
+++ b/packages/eventcatalog-utils/src/services.ts
@@ -18,67 +18,72 @@ const readMarkdownFile = (pathToFile: string) => {
 
 export const buildServiceMarkdownForCatalog =
   () =>
-  (service: Service, { markdownContent, renderMermaidDiagram = false, renderNodeGraph = true }: any = {}) =>
-    buildMarkdownFile({
-      frontMatterObject: service,
-      customContent: markdownContent,
-      renderMermaidDiagram,
-      renderNodeGraph,
-    });
+    (service: Service, { markdownContent, renderMermaidDiagram = false, renderNodeGraph = true, includeAsyncApiComponent = false }: any = {}) =>
+      buildMarkdownFile({
+        frontMatterObject: service,
+        customContent: markdownContent,
+        renderMermaidDiagram,
+        renderNodeGraph,
+        includeAsyncApiComponent
+      });
 
 export const getAllServicesFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  (): any[] => {
-    const servicesDir = path.join(catalogDirectory, 'services');
-    const folders = fs.readdirSync(servicesDir);
-    return folders.map((folder) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { raw, ...service }: any = getServiceFromCatalog({ catalogDirectory })(folder);
-      return service;
-    });
-  };
+    (): any[] => {
+      const servicesDir = path.join(catalogDirectory, 'services');
+      const folders = fs.readdirSync(servicesDir);
+      return folders.map((folder) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { raw, ...service }: any = getServiceFromCatalog({ catalogDirectory })(folder);
+        return service;
+      });
+    };
 
 export const getServiceFromCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  (seriveName: string) => {
-    try {
-      // Read the directory to get the stuff we need.
-      const { parsed: parsedService, raw } = readMarkdownFile(path.join(catalogDirectory, 'services', seriveName, 'index.md'));
-      return {
-        data: parsedService.data,
-        content: parsedService.content,
-        raw,
-      };
-    } catch (error) {
-      return null;
-    }
-  };
+    (seriveName: string) => {
+      try {
+        // Read the directory to get the stuff we need.
+        const { parsed: parsedService, raw } = readMarkdownFile(path.join(catalogDirectory, 'services', seriveName, 'index.md'));
+        return {
+          data: parsedService.data,
+          content: parsedService.content,
+          raw,
+        };
+      } catch (error) {
+        return null;
+      }
+    };
 
 export const writeServiceToCatalog =
   ({ catalogDirectory }: FunctionInitInterface) =>
-  (service: Service, options?: WriteServiceToCatalogInterface): WriteServiceToCatalogInterfaceReponse => {
-    const { name: serviceName } = service;
-    const { useMarkdownContentFromExistingService = true, renderMermaidDiagram = false, renderNodeGraph = true } = options || {};
-    let markdownContent;
+    (service: Service, options?: WriteServiceToCatalogInterface): WriteServiceToCatalogInterfaceReponse => {
+      const { name: serviceName } = service;
+      const { useMarkdownContentFromExistingService = true, renderMermaidDiagram = false, renderNodeGraph = true, asyncApiFile } = options || {};
+      let markdownContent;
 
-    if (!serviceName) throw new Error('No `name` found for given service');
+      if (!serviceName) throw new Error('No `name` found for given service');
 
-    if (useMarkdownContentFromExistingService) {
-      const data = getServiceFromCatalog({ catalogDirectory })(serviceName);
-      markdownContent = data?.content ? data?.content : '';
-    }
+      if (useMarkdownContentFromExistingService) {
+        const data = getServiceFromCatalog({ catalogDirectory })(serviceName);
+        markdownContent = data?.content ? data?.content : '';
+      }
 
-    const data = buildServiceMarkdownForCatalog()(service, {
-      markdownContent,
-      useMarkdownContentFromExistingService,
-      renderMermaidDiagram,
-      renderNodeGraph,
-    });
+      const data = buildServiceMarkdownForCatalog()(service, {
+        markdownContent,
+        useMarkdownContentFromExistingService,
+        renderMermaidDiagram,
+        renderNodeGraph,
+        includeAsyncApiComponent: !!asyncApiFile
+      });
 
-    fs.ensureDirSync(path.join(catalogDirectory, 'services', service.name));
-    fs.writeFileSync(path.join(catalogDirectory, 'services', service.name, 'index.md'), data);
+      fs.ensureDirSync(path.join(catalogDirectory, 'services', service.name));
+      fs.writeFileSync(path.join(catalogDirectory, 'services', service.name, 'index.md'), data);
 
-    return {
-      path: path.join(catalogDirectory, 'services', service.name),
+      if (asyncApiFile && asyncApiFile.extension && asyncApiFile.fileContent) {
+        fs.writeFileSync(path.join(catalogDirectory, 'services', service.name,`asyncapi.${asyncApiFile.extension}`), asyncApiFile.fileContent);
+      }
+      return {
+        path: path.join(catalogDirectory, 'services', service.name),
+      };
     };
-  };

--- a/packages/eventcatalog-utils/src/types.ts
+++ b/packages/eventcatalog-utils/src/types.ts
@@ -6,6 +6,7 @@ export interface WriteServiceToCatalogInterface {
   useMarkdownContentFromExistingService?: boolean;
   renderMermaidDiagram?: boolean;
   renderNodeGraph?: boolean;
+  asyncApiFile?: AsyncApiFile;
 }
 
 export interface WriteServiceToCatalogInterfaceReponse {
@@ -17,6 +18,10 @@ export interface WriteEventToCatalogResponse {
 }
 
 export interface SchemaFile {
+  extension: string;
+  fileContent: string;
+}
+export interface AsyncApiFile {
   extension: string;
   fileContent: string;
 }


### PR DESCRIPTION
Add the AsyncApi component  and save it in the service folder when you generate events from an AsyncAPI file. 
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I'm creating my own AsyncAPI generator based on the new AsyncAPI parser (version 2) and wanted to pass the asyncAPI file to the writeServiceToCatalog so a the AsyncAPI component is added the the service page and the file is saved under the service folder (the same way the schema is provided to the writeEventToCatalog and saved in the event folder). so I don't need to do any manual work, when you generate the service and events using the generator the AsyncAPI file used is saved in the service folder and shown in the serve page.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
