### PR TITLE
feat: sort sidebar filters

### DIFF
--- a/.changeset/curvy-pillows-argue.md
+++ b/.changeset/curvy-pillows-argue.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat: sort sidebar filters

--- a/packages/eventcatalog/pages/domains.tsx
+++ b/packages/eventcatalog/pages/domains.tsx
@@ -135,22 +135,24 @@ export default function Page({ domains }: PageProps) {
                     </h3>
                     <div className="pt-6">
                       <div className="space-y-4">
-                        {section.options.map((option, optionIdx) => (
-                          <div key={option.value} className="flex items-center">
-                            <input
-                              id={`filter-${section.id}-${optionIdx}`}
-                              name={`${section.id}[]`}
-                              defaultValue={option.value}
-                              type="checkbox"
-                              onChange={(event) => handleFilterSelection(option, section.id, event)}
-                              defaultChecked={option.checked}
-                              className="h-4 w-4 border-gray-300 rounded text-gray-600 focus:ring-gray-500"
-                            />
-                            <label htmlFor={`filter-${section.id}-${optionIdx}`} className="ml-3 text-sm text-gray-600">
-                              {option.label}
-                            </label>
-                          </div>
-                        ))}
+                        {section.options
+                          .sort((a, b) => a.value.localeCompare(b.value))
+                          .map((option, optionIdx) => (
+                            <div key={option.value} className="flex items-center">
+                              <input
+                                id={`filter-${section.id}-${optionIdx}`}
+                                name={`${section.id}[]`}
+                                defaultValue={option.value}
+                                type="checkbox"
+                                onChange={(event) => handleFilterSelection(option, section.id, event)}
+                                defaultChecked={option.checked}
+                                className="h-4 w-4 border-gray-300 rounded text-gray-600 focus:ring-gray-500"
+                              />
+                              <label htmlFor={`filter-${section.id}-${optionIdx}`} className="ml-3 text-sm text-gray-600">
+                                {option.label}
+                              </label>
+                            </div>
+                          ))}
                       </div>
                     </div>
                   </div>

--- a/packages/eventcatalog/pages/events.tsx
+++ b/packages/eventcatalog/pages/events.tsx
@@ -238,22 +238,24 @@ export default function Page({ events, services, domains }: PageProps) {
                     </h3>
                     <div className="pt-6">
                       <div className="space-y-4">
-                        {section.options.map((option, optionIdx) => (
-                          <div key={option.value} className="flex items-center">
-                            <input
-                              id={`filter-${section.id}-${optionIdx}`}
-                              name={`${section.id}[]`}
-                              defaultValue={option.value}
-                              type="checkbox"
-                              onChange={(event) => handleFilterSelection(option, section.id, event)}
-                              defaultChecked={option.checked}
-                              className="h-4 w-4 border-gray-300 rounded text-gray-600 focus:ring-gray-500"
-                            />
-                            <label htmlFor={`filter-${section.id}-${optionIdx}`} className="ml-3 text-sm text-gray-600">
-                              {option.label}
-                            </label>
-                          </div>
-                        ))}
+                        {section.options
+                          .sort((a, b) => a.value.localeCompare(b.value))
+                          .map((option, optionIdx) => (
+                            <div key={option.value} className="flex items-center">
+                              <input
+                                id={`filter-${section.id}-${optionIdx}`}
+                                name={`${section.id}[]`}
+                                defaultValue={option.value}
+                                type="checkbox"
+                                onChange={(event) => handleFilterSelection(option, section.id, event)}
+                                defaultChecked={option.checked}
+                                className="h-4 w-4 border-gray-300 rounded text-gray-600 focus:ring-gray-500"
+                              />
+                              <label htmlFor={`filter-${section.id}-${optionIdx}`} className="ml-3 text-sm text-gray-600">
+                                {option.label}
+                              </label>
+                            </div>
+                          ))}
                       </div>
                     </div>
                   </div>

--- a/packages/eventcatalog/pages/services.tsx
+++ b/packages/eventcatalog/pages/services.tsx
@@ -193,22 +193,24 @@ export default function Page({ services }: PageProps) {
                     </h3>
                     <div className="pt-6">
                       <div className="space-y-4">
-                        {section.options.map((option, optionIdx) => (
-                          <div key={option.value} className="flex items-center">
-                            <input
-                              id={`filter-${section.id}-${optionIdx}`}
-                              name={`${section.id}[]`}
-                              defaultValue={option.value}
-                              type="checkbox"
-                              onChange={(event) => handleFilterSelection(option, section.id, event)}
-                              defaultChecked={option.checked}
-                              className="h-4 w-4 border-gray-300 rounded text-gray-600 focus:ring-gray-500"
-                            />
-                            <label htmlFor={`filter-${section.id}-${optionIdx}`} className="ml-3 text-sm text-gray-600">
-                              {option.label}
-                            </label>
-                          </div>
-                        ))}
+                        {section.options
+                          .sort((a, b) => a.value.localeCompare(b.value))
+                          .map((option, optionIdx) => (
+                            <div key={option.value} className="flex items-center">
+                              <input
+                                id={`filter-${section.id}-${optionIdx}`}
+                                name={`${section.id}[]`}
+                                defaultValue={option.value}
+                                type="checkbox"
+                                onChange={(event) => handleFilterSelection(option, section.id, event)}
+                                defaultChecked={option.checked}
+                                className="h-4 w-4 border-gray-300 rounded text-gray-600 focus:ring-gray-500"
+                              />
+                              <label htmlFor={`filter-${section.id}-${optionIdx}`} className="ml-3 text-sm text-gray-600">
+                                {option.label}
+                              </label>
+                            </div>
+                          ))}
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Motivation

It is difficult to navigate the sidebar filters with too many unsorted events to choose.

This PR sorts them, this is the result:

### Before
![before](https://github.com/boyney123/eventcatalog/assets/12160864/bcec3b91-3e4a-4d8a-8444-def0f51e09b2)

### After
![after](https://github.com/boyney123/eventcatalog/assets/12160864/65c37d2c-720d-4164-83e4-0c0c5c6ae31a)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.