### PR TITLE
feat: Allow fetching of remote asyncapi docs

### DIFF
--- a/.changeset/khaki-doors-move.md
+++ b/.changeset/khaki-doors-move.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat: Allow fetching of remote asyncapi docs

--- a/packages/eventcatalog/components/Mdx/AsyncApiSpec.tsx
+++ b/packages/eventcatalog/components/Mdx/AsyncApiSpec.tsx
@@ -10,7 +10,7 @@ const config = {
 };
 
 interface AsyncApiSpecProps {
-  spec: string;
+  spec?: string;
   url?: string;
 }
 

--- a/packages/eventcatalog/components/Mdx/AsyncApiSpec.tsx
+++ b/packages/eventcatalog/components/Mdx/AsyncApiSpec.tsx
@@ -11,12 +11,15 @@ const config = {
 
 interface AsyncApiSpecProps {
   spec: string;
+  url?: string;
 }
 
-export default function AsyncApiSpec({ spec }: AsyncApiSpecProps) {
+export default function AsyncApiSpec({ spec, url }: AsyncApiSpecProps) {
+  const schema = !url ? spec : { url };
+
   return (
     <div className={`my-4 border border-gray-300 border-dashed px-5 `}>
-      <AsyncApiComponent schema={spec} config={config} />
+      <AsyncApiComponent schema={schema} config={config} />
     </div>
   );
 }

--- a/packages/eventcatalog/pages/services/[name].tsx
+++ b/packages/eventcatalog/pages/services/[name].tsx
@@ -37,8 +37,8 @@ function MermaidComponent({ title, service, charts }: { title?: string; service:
 const getComponents = (service: Service) => ({
   Admonition,
   AsyncAPI: ({ url }: { url?: string }) => {
-    if(url) return <AsyncApiSpec url={url} />
-    
+    if (url) return <AsyncApiSpec url={url} />;
+
     if (!service.asyncAPISpec && !url) return null;
     return <AsyncApiSpec spec={service.asyncAPISpec} />;
   },

--- a/packages/eventcatalog/pages/services/[name].tsx
+++ b/packages/eventcatalog/pages/services/[name].tsx
@@ -37,8 +37,10 @@ function MermaidComponent({ title, service, charts }: { title?: string; service:
 const getComponents = (service: Service) => ({
   Admonition,
   AsyncAPI: ({ url }: { url?: string }) => {
-    if (!service.asyncAPISpec) return null;
-    return <AsyncApiSpec spec={service.asyncAPISpec} url={url} />;
+    if(url) return <AsyncApiSpec url={url} />
+    
+    if (!service.asyncAPISpec && !url) return null;
+    return <AsyncApiSpec spec={service.asyncAPISpec} />;
   },
   OpenAPI: ({ url, ...props }: { url?: string }) => {
     if (!service.openAPISpec) return null;

--- a/packages/eventcatalog/pages/services/[name].tsx
+++ b/packages/eventcatalog/pages/services/[name].tsx
@@ -36,9 +36,9 @@ function MermaidComponent({ title, service, charts }: { title?: string; service:
 
 const getComponents = (service: Service) => ({
   Admonition,
-  AsyncAPI: () => {
+  AsyncAPI: ({ url }: { url?: string }) => {
     if (!service.asyncAPISpec) return null;
-    return <AsyncApiSpec spec={service.asyncAPISpec} />;
+    return <AsyncApiSpec spec={service.asyncAPISpec} url={url} />;
   },
   OpenAPI: ({ url, ...props }: { url?: string }) => {
     if (!service.openAPISpec) return null;

--- a/website/docs/guides/components/overview.md
+++ b/website/docs/guides/components/overview.md
@@ -200,6 +200,13 @@ To understand how it works and use AsyncAPI with your Services checkout the [sch
 
 #### Props
 
+<APITable>
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| `url` | `string` | `` | Optional URL to load your AsyncAPI file. If you provide a URL to load this will be used over the local file system and the file will be loaded from external URL. |
+</APITable>
+
 #### Rendered Example 
 ![AsyncAPI Example](/img/guides/mdx/asyncapi.gif)
 

--- a/website/docs/guides/components/services.md
+++ b/website/docs/guides/components/services.md
@@ -18,5 +18,5 @@ Here is the supported list of components you can use:
 - **[<OpenAPI /\>](/docs/components/overview#openapi-)**
     - Displays [Swagger UI](https://petstore.swagger.io/?_ga=2.53430379.2146201950.1646656985-1065913731.1646656985) for your `openapi.yaml` files.
 - **[<AsyncAPI /\>](/docs/components/overview#asyncapi-)**
-    - Displays [AsyncAPI React Componnet](https://github.com/asyncapi/asyncapi-react) for your `asyncapi.yml` files.
+    - Displays [AsyncAPI React Component](https://github.com/asyncapi/asyncapi-react) for your `asyncapi.yml` files.
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Related to #378 and #387. This PR allows the AsyncAPI docs to be fetched from a remote URL by exposing a new AsyncAPI component option (url). Under-the-hood, it uses [FetchingSchemaInterface](https://github.com/asyncapi/asyncapi-react/blob/master/library/src/types.ts#L396) when the url option is specified.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
