### PR TITLE
Eventcatalog plugin generator amazon eventbridge frontmatter config

### DIFF
--- a/.changeset/sweet-badgers-obey.md
+++ b/.changeset/sweet-badgers-obey.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/plugin-doc-generator-amazon-eventbridge": patch
+---
+
+feat - Amazon EventBridge plugin now persists producers and consumers

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/assets/event-markdown-snapshot.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/assets/event-markdown-snapshot.ts
@@ -18,10 +18,12 @@ externalLinks:
     - {label: 'View Schema AWS Console', url: 'https://eu-west-1.console.aws.amazon.com/events/home?region=eu-west-1#/registries/discovered-schemas/schemas/users@UserCreated'}
 badges: []
 owners: []
+producers: []
+consumers: []
 ---
 ## Matched rules for event
 
-The event \`users@UserCreated\` has **2** matched rules on the event bus **'test-event-bus'**.  
+The event \`users@UserCreated\` has **2** matched rules on the event bus **'test-event-bus'**.
 
 | Rules | Number Of Targets | Targets | Metrics |
 | --- | ------ | ----------- | ----------- |
@@ -44,7 +46,7 @@ usercreated-to-hello-world{{usercreated-to-hello-world}}:::rule-- fa:fa-cloud se
 <Schema />
 
 <EventExamples />
-    
+
     `;
 
 export default {

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/plugin.spec.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/__tests__/plugin.spec.ts
@@ -168,12 +168,14 @@ describe('eventcatalog-plugin-generator-amazon-eventbridge', () => {
         expect(fs.existsSync(path.join(eventPath, 'versioned', '0.1', 'schema.json'))).toEqual(true);
       });
 
-      it('when new events are created in the catalog the `owners` from the previous version of the event is used in the new event metdata', async () => {
+      it('when new events are created in the catalog the `owners`, `producers` and `consumers` from the previous version of the event is used in the new event metdata', async () => {
         const oldEventFromAWSAlreadyInCatalog = {
           name: 'users@UserCreated',
           version: '0.1',
           summary: 'really old version of this event',
           owners: ['dboyne', 'tSmith'],
+          producers: ['Service A'],
+          consumers: ['Service B'],
         };
 
         const eventPath = path.join(process.env.PROJECT_DIR, 'events', 'users@UserCreated');
@@ -196,6 +198,8 @@ describe('eventcatalog-plugin-generator-amazon-eventbridge', () => {
 
         expect(newEventData.version).toEqual('1');
         expect(newEventData.owners).toEqual(['dboyne', 'tSmith']);
+        expect(newEventData.producers).toEqual(['Service A']);
+        expect(newEventData.consumers).toEqual(['Service B']);
       });
     });
 

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/index.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/index.ts
@@ -77,6 +77,8 @@ export default async (_: LoadContext, options: PluginOptions) => {
       },
       frontMatterToCopyToNewVersions: {
         owners: true,
+        producers: true,
+        consumers: true,
       },
       versionExistingEvent: versionEvents && versionChangedFromPreviousEvent,
       useMarkdownContentFromExistingEvent: true,
@@ -88,9 +90,9 @@ export default async (_: LoadContext, options: PluginOptions) => {
   });
 
   console.log(
-    chalk.green(`  
-  Succesfully parsed "${schemas.length}" schemas from "${eventBusName}" event bus. 
-  
+    chalk.green(`
+  Succesfully parsed "${schemas.length}" schemas from "${eventBusName}" event bus.
+
   Generated ${events.length} events for EventCatalog.
 `)
   );


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://github.com/boyney123/eventcatalog/blob/main/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

eventcatalog-plugin-generator-amazon-eventbridge plugin does not populate the frontmatter fields `producers` and `consumers`. The generate command does however always drop these fields even if they had been manually updated. This is confusing behavior. This PR extends the same retain policy that was previously only applied to the `owners` field to also include `producers` and `consumers`.

Tests have been updated to account for the change and all tests pass.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes
