### PR TITLE
fix- build for typescript and react types

### DIFF
--- a/.changeset/new-points-wink.md
+++ b/.changeset/new-points-wink.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix- build for typescript and react types

--- a/packages/eventcatalog/pages/overview.tsx
+++ b/packages/eventcatalog/pages/overview.tsx
@@ -55,6 +55,7 @@ function Graph({ events, services }: PageProps) {
         nodeRelSize={9}
         nodeThreeObject={(node) => {
           const nodeEl = document.createElement('div');
+          // @ts-ignore
           nodeEl.innerHTML = ReactDOMServer.renderToString(<NodeElement node={node} />);
           node.height = '100px';
           nodeEl.style.color = node.color;


### PR DESCRIPTION
## Motivation

Getting this error on build

```
Argument of type 'Element' is not assignable to parameter of type 'ReactElement<any, string | JSXElementConstructor<any>>'.
  Types of property 'key' are incompatible.
    Type 'React.Key' is not assignable to type 'import("/Users/dboyne/Dev/OpenSource/eventcatalog-pull-requests/my-catalog/node_modules/@types/react-dom/node_modules/@types/react/index").Key'.
      Type 'bigint' is not assignable to type 'Key'.

  56 |         nodeThreeObject={(node) => {
  57 |           const nodeEl = document.createElement('div');
> 58 |           nodeEl.innerHTML = ReactDOMServer.renderToString(<NodeElement node={node} />);
     |
```

This fix, removes the error by a typescript ignore. 
