### PR TITLE
fix: fixing TypeScript version on new catalogs to v5 from v4

### DIFF
--- a/.changeset/old-meals-float.md
+++ b/.changeset/old-meals-float.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/create-eventcatalog": patch
+---
+
+fix: fixing TypeScript version on new catalogs to v5 from v4

--- a/packages/create-eventcatalog/create-app.ts
+++ b/packages/create-eventcatalog/create-app.ts
@@ -170,7 +170,7 @@ export async function createApp({
       },
       devDependencies: {
         tailwindcss: '^3.3.3',
-        typescript: "^5.1.6",
+        typescript: '^5.1.6',
         postcss: '^8.3.11',
         'cross-env': '^7.0.3',
         autoprefixer: '10.4.5',

--- a/packages/create-eventcatalog/create-app.ts
+++ b/packages/create-eventcatalog/create-app.ts
@@ -170,7 +170,7 @@ export async function createApp({
       },
       devDependencies: {
         tailwindcss: '^3.3.3',
-        typescript: '^4.4.4',
+        typescript: "^5.1.6",
         postcss: '^8.3.11',
         'cross-env': '^7.0.3',
         autoprefixer: '10.4.5',


### PR DESCRIPTION

## Motivation

We updated to TypeScript v5 looks like the EventCatalog CLI package was left behind in the migration, this fixes that issue also mentioned in #450
