### PR TITLE
Schema discovery upgrade

### DIFF
--- a/.changeset/pink-carrots-rush.md
+++ b/.changeset/pink-carrots-rush.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/plugin-doc-generator-amazon-eventbridge": patch
+---
+
+fix - eventbridge plugin now fetches over 100 schemas and also allows filtering

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/scripts/generate-catalog-with-plugin.js
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/scripts/generate-catalog-with-plugin.js
@@ -15,6 +15,7 @@ const main = async () => {
       eventBusName: process.env.EVENT_BUS_NAME,
       region: process.env.REGION,
       registryName: process.env.SCHEMA_REGISTRY_NAME,
+      schemaNamePrefix: process.env.SCHEMA_NAME_PREFIX,
     }
   );
 };

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/lib/aws.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/lib/aws.ts
@@ -1,6 +1,12 @@
 import { EventBridge, Rule } from '@aws-sdk/client-eventbridge';
 import { Arn, ArnFormat } from 'aws-cdk-lib';
-import { Schemas, Schemas as SchemaSDK, ExportSchemaCommandOutput, ForbiddenException } from '@aws-sdk/client-schemas';
+import {
+  Schemas,
+  Schemas as SchemaSDK,
+  ExportSchemaCommandOutput,
+  ForbiddenException,
+  SchemaSummary
+} from '@aws-sdk/client-schemas';
 import { PluginOptions } from '../types';
 
 export interface CustomSchema extends ExportSchemaCommandOutput {
@@ -12,7 +18,14 @@ export interface CustomSchema extends ExportSchemaCommandOutput {
 
 const getSchemas = (schemas: SchemaSDK, registryName: string) => async (): Promise<CustomSchema[]> => {
   // First get all schemas
-  const { Schemas: registrySchemas = [] } = await schemas.listSchemas({ RegistryName: registryName });
+  let nextToken: string | undefined;
+  let registrySchemas: SchemaSummary[] = [];
+  do {
+    // eslint-disable-next-line no-await-in-loop
+    const {Schemas: batchRegistrySchemas = [], NextToken: token} = await schemas.listSchemas({RegistryName: registryName, NextToken: nextToken});
+    registrySchemas = registrySchemas.concat(batchRegistrySchemas);
+    nextToken = token;
+  } while (nextToken !== undefined);
 
   const allSchemas = registrySchemas.map(async (registrySchema: any) => {
     let schemaAsJSON: ExportSchemaCommandOutput = { $metadata: {} };

--- a/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/types.ts
+++ b/packages/eventcatalog-plugin-generator-amazon-eventbridge/src/types.ts
@@ -14,4 +14,5 @@ export interface PluginOptions {
   registryName: string;
   schemaTypeToRenderToEvent?: SchemaTypes;
   versionEvents?: boolean;
+  schemaNamePrefix?: string;
 }

--- a/website/docs/api/plugins/plugin-doc-generator-amazon-eventbridge.md
+++ b/website/docs/api/plugins/plugin-doc-generator-amazon-eventbridge.md
@@ -88,6 +88,7 @@ module.exports = {
         eventBusName: 'boyne-test-bus', // your event bus name
         region: 'us-west-1', // your region
         registryName: 'discovered-schemas', // your registry normally "discovered-schemas"
+        schemaNamePrefix: 'my-prefix', // Schema name prefix filter, optional
         credentials: {
           accessKeyId: process.env.AWS_ACCESS_KEY,
           secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
@@ -115,13 +116,14 @@ This command will run through your plugin and generate your EventCatalog documen
 <APITable>
 
 | Name | Type | Default | Description |
-| --- | --- | --- | --- |
+| --- | --- | --- |  |
 | `eventBusName` | `string` | `` | Name of your EventBus |
 | `region` | `string` | `` | AWS Region of your eventbus |
 | `registryName` | `string` | `` | Name of your Schema Registry |
 | `credentials` | `AWSCredentials`- [View Schema](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Credentials.html) | `` | AWS `accessKeyId` and `secretAccessKey` |
 | `schemaTypeToRenderToEvent` | `string` (`JSONSchemaDraft4`/`OpenAPI`) | `JSONSchemaDraft4` | Schema type to render along side your event in EventCatalog |
 | `versionEvents` | `boolean` | `true` | Version your events as new versions get detected from your Schema Registry |
+| `schemaNamePrefix` | `string` | `` | Schema name prefix used to filter retrieved schemas |
 
 </APITable>
 


### PR DESCRIPTION
Hello !

Fix #425
Fix #426

## Motivation

I opened few weeks ago two issues:

 - #425: A "bug" that lead the even catalog generator from EventBridge to only retrieve first 100 events
 - #426: A feature request to allow use AWS sdk option `SchemaNamePrefix` to filter events

My company as a lot of different events, part because we use a global event bus with all project/environments push on it. So we have:

 - More than 100 events schemas
 - I am only interested by "production" ones that I can easily filter with the schema name prefix.

That will allow us use the project to document our events.

All changes relate to this AWS SDK function: [listSchemas](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Schemas.html#listSchemas-property)

NB: It is my first contribution to this project and I am not a regular TS developer, hope all will be good.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/boyney123/eventcatalog/blob/master/CONTRIBUTING.md#pull-requests)?

Yes