### PR TITLE
fix - copy config file on build

### DIFF
--- a/.changeset/great-bulldogs-breathe.md
+++ b/.changeset/great-bulldogs-breathe.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+fix - copy config file on build

--- a/packages/eventcatalog/bin/eventcatalog.js
+++ b/packages/eventcatalog/bin/eventcatalog.js
@@ -50,6 +50,9 @@ cli
     // copy any public assets over (from users to the lib itself)
     fs.copySync(path.join(projectDIR, 'public'), path.join(eventCatalogLibDir, 'public'));
 
+    // Copy the eventcatalog file over
+    fs.copyFileSync(path.join(projectDIR, 'eventcatalog.config.js'), path.join(eventCatalogLibDir, 'eventcatalog.config.js'));
+
     // Move the schemas into public directory so we can download them from UI
     execSync(`cross-env PROJECT_DIR='${projectDIR}' npm run scripts:move-schema-for-download`, {
       cwd: eventCatalogLibDir,


### PR DESCRIPTION
## Motivation

When running the build command, the users `eventcatalog.config` file was not copied over, always resulting to the default one. This PR fixes that issue.

