### PR TITLE
fix: (#484) ensure link exists before opening link in visualizer

### DIFF
--- a/packages/eventcatalog/components/Mdx/NodeGraph/NodeGraph.tsx
+++ b/packages/eventcatalog/components/Mdx/NodeGraph/NodeGraph.tsx
@@ -104,7 +104,12 @@ function NodeGraphBuilder({
   }, [data, getElements, isHorizontal, resetView]);
 
   // ReactFlow operations
-  const onElementClick = (event, element) => window.open(element.data.link, '_self');
+  const onElementClick = (event, element) => {
+    if (element.data?.link) {
+      window.open(element.data.link, '_self');
+    }
+  }
+
   const onLoad = useCallback(
     (reactFlowInstance) => {
       if (fitView) {


### PR DESCRIPTION
## Motivation

Fixing bug described in #484

Adding a conditional to the `ReactFlow`'s `onElementClick` callback function to ensure a link actually exists before navigating to it