### PR TITLE
feat: add search via query parameter for events, services and domains (#498)

### DIFF
--- a/.changeset/cyan-zebras-happen.md
+++ b/.changeset/cyan-zebras-happen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/core": patch
+---
+
+feat: add search via query parameter for events, services and domains (#498)

--- a/packages/eventcatalog/pages/domains.tsx
+++ b/packages/eventcatalog/pages/domains.tsx
@@ -7,6 +7,7 @@ import { SearchIcon } from '@heroicons/react/outline';
 import DomainGrid from '@/components/Grids/DomainGrid';
 import { useConfig } from '@/hooks/EventCatalog';
 import { getAllDomains } from '@/lib/domains';
+import { useRouter } from 'next/router';
 
 export interface PageProps {
   domains: Domain[];
@@ -80,6 +81,14 @@ export default function Page({ domains }: PageProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFilters, searchFilter]);
 
+  const router = useRouter();
+
+  useEffect(() => {
+    if (router.query.q) {
+      setSearchFilter(router.query.q as string);
+    }
+  }, [router.query.q]);
+
   const debouncedFilter = useCallback(
     debounce((e) => {
       setSearchFilter(e.target.value);
@@ -116,7 +125,11 @@ export default function Page({ domains }: PageProps) {
                     type="text"
                     name="domain"
                     id="domain"
-                    onChange={debouncedFilter}
+                    onChange={(e) => {
+                      setSearchFilter(e.target.value);
+                      debouncedFilter(e);
+                    }}
+                    value={searchFilter}
                     className="focus:ring-gray-500 focus:border-gray-500 block w-full pl-10 sm:text-sm border-gray-300 rounded-md"
                   />
                 </div>

--- a/packages/eventcatalog/pages/events.tsx
+++ b/packages/eventcatalog/pages/events.tsx
@@ -9,6 +9,7 @@ import EventGrid from '@/components/Grids/EventGrid';
 import { getAllEvents, getUniqueServicesNamesFromEvents } from '@/lib/events';
 import { getUniqueDomainNamesFromEvents } from '@/lib/domains';
 import { useConfig } from '@/hooks/EventCatalog';
+import { useRouter } from 'next/router';
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
@@ -134,6 +135,14 @@ export default function Page({ events, services, domains }: PageProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFilters, searchFilter]);
 
+  const router = useRouter();
+
+  useEffect(() => {
+    if (router.query.q) {
+      setSearchFilter(router.query.q as string);
+    }
+  }, [router.query.q]);
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedFilter = useCallback(
     debounce((e) => {
@@ -220,7 +229,11 @@ export default function Page({ events, services, domains }: PageProps) {
                     type="text"
                     name="event"
                     id="event"
-                    onChange={debouncedFilter}
+                    onChange={(e) => {
+                      setSearchFilter(e.target.value);
+                      debouncedFilter(e);
+                    }}
+                    value={searchFilter}
                     className="focus:ring-gray-500 focus:border-gray-500 block w-full pl-10 sm:text-sm border-gray-300 rounded-md"
                   />
                 </div>

--- a/packages/eventcatalog/pages/services.tsx
+++ b/packages/eventcatalog/pages/services.tsx
@@ -8,6 +8,7 @@ import { ChevronDownIcon, SearchIcon } from '@heroicons/react/solid';
 import ServiceGrid from '@/components/Grids/ServiceGrid';
 import { getAllServices } from '@/lib/services';
 import { useConfig } from '@/hooks/EventCatalog';
+import { useRouter } from 'next/router';
 
 function classNames(...classes) {
   return classes.filter(Boolean).join(' ');
@@ -90,6 +91,14 @@ export default function Page({ services }: PageProps) {
     setServicesToRender(getFilteredServices());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFilters, searchFilter]);
+
+  const router = useRouter();
+
+  useEffect(() => {
+    if (router.query.q) {
+      setSearchFilter(router.query.q as string);
+    }
+  }, [router.query.q]);
 
   const debouncedFilter = useCallback(
     debounce((e) => {
@@ -174,7 +183,11 @@ export default function Page({ services }: PageProps) {
                     type="text"
                     name="service"
                     id="service"
-                    onChange={debouncedFilter}
+                    onChange={(e) => {
+                      setSearchFilter(e.target.value);
+                      debouncedFilter(e);
+                    }}
+                    value={searchFilter}
                     className="focus:ring-gray-500 focus:border-gray-500 block w-full pl-10 sm:text-sm border-gray-300 rounded-md"
                   />
                 </div>


### PR DESCRIPTION
## Motivation

Implementing suggestion described here (#498)

Changed the input to be a react managed component and checking if the query string "q" is provided.

Can be tested locally calling http://localhost:3000/events/?q=Order and http://localhost:3000/services/?q=Order and http://localhost:3000/domains/?q=Order 

The expected behaviour is that the result list be filtered by the term in the query parameter "q".

Let me know if you have a different suggestion for query parameter.